### PR TITLE
Increase timeout of install.IsRunning

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -28,6 +28,10 @@ const (
 	// TimeoutDefault is the default install timeout.
 	TimeoutDefault = 30 * time.Second
 
+	// installWaitNumMaxPolls is the maximum number of API operations to be
+	// performed in sequence while waiting for the component to be installed.
+	installWaitNumMaxPolls = 60
+
 	fryKey                      = "com.docker.fry"
 	imageTagKey                 = "com.docker.image-tag"
 	namespaceKey                = "com.docker.deploy-namespace"
@@ -171,7 +175,7 @@ func IsRunning(config *rest.Config) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			err = wait.For(10, func() (bool, error) {
+			err = wait.For(installWaitNumMaxPolls, func() (bool, error) {
 				_, err := stackClient.ComposeV1beta2().Stacks("e2e").List(metav1.ListOptions{})
 				if err != nil {
 					return false, nil


### PR DESCRIPTION
As of kubernetes/kubernetes#66932, included in Kubernetes 1.11.3, the Kubernetes API Server will list unavailable services in its discovery response. This causes the installation to time out after 10 retries, with the following API errors:

```
2018-12-04T22:46:35.687398778Z {"level":"debug","msg":"unable to list composev1beta2 stack: the server could not find the requested resource (get stacks.compose.docker.com)","time":"2018-12-04T22:46:35Z"}
2018-12-04T22:46:36.689666183Z {"level":"debug","msg":"unable to list composev1beta2 stack: the server could not find the requested resource (get stacks.compose.docker.com)","time":"2018-12-04T22:46:36Z"}
2018-12-04T22:46:37.691736596Z {"level":"debug","msg":"unable to list composev1beta2 stack: the server could not find the requested resource (get stacks.compose.docker.com)","time":"2018-12-04T22:46:37Z"}
2018-12-04T22:46:38.693851921Z {"level":"debug","msg":"unable to list composev1beta2 stack: the server could not find the requested resource (get stacks.compose.docker.com)","time":"2018-12-04T22:46:38Z"}
2018-12-04T22:46:39.696159504Z {"level":"debug","msg":"unable to list composev1beta2 stack: the server could not find the requested resource (get stacks.compose.docker.com)","time":"2018-12-04T22:46:39Z"}
2018-12-04T22:46:40.698704843Z {"level":"debug","msg":"unable to list composev1beta2 stack: the server is currently unable to handle the request (get stacks.compose.docker.com)","time":"2018-12-04T22:46:40Z"}
2018-12-04T22:46:41.701443251Z {"level":"debug","msg":"unable to list composev1beta2 stack: the server is currently unable to handle the request (get stacks.compose.docker.com)","time":"2018-12-04T22:46:41Z"}
2018-12-04T22:46:42.711996071Z {"level":"debug","msg":"unable to list composev1beta1 stack: the server is currently unable to handle the request (get stacks.compose.docker.com)","time":"2018-12-04T22:46:42Z"}
2018-12-04T22:46:43.718401701Z {"level":"debug","msg":"unable to list composev1beta1 stack: the server is currently unable to handle the request (get stacks.compose.docker.com)","time":"2018-12-04T22:46:43Z"}
2018-12-04T22:46:44.725650018Z {"level":"debug","msg":"unable to list composev1beta1 stack: the server is currently unable to handle the request (get stacks.compose.docker.com)","time":"2018-12-04T22:46:44Z"}
```

This PR parameterizes and increases the number of retries to 60, which should reduce flaky behavior of the installer.