### PR TITLE
Bump k8s vendoring and e2e tests environements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,8 +134,8 @@ jobs:
       - run:
           name: Tear down testkit cluster (on failure)
           command: |
-            KUBE_VERSION=1.10.5 ./scripts/e2e-cluster.sh delete
-            KUBE_VERSION=1.11.4 ./scripts/e2e-cluster.sh delete
+            KUBE_VERSION=1.10.11 ./scripts/e2e-cluster.sh delete
+            KUBE_VERSION=1.11.5 ./scripts/e2e-cluster.sh delete
           when: on_fail
       - persist_to_workspace:
           root: /root/
@@ -165,51 +165,51 @@ jobs:
     docker: *compose-ci-docker
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
-      - KUBE_VERSION: 1.10.5
+      - KUBE_VERSION: 1.10.11
     steps: *cluster-setup-steps
   cluster-setup-1_11:
     docker: *compose-ci-docker
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
-      - KUBE_VERSION: 1.11.4
+      - KUBE_VERSION: 1.11.5
     steps: *cluster-setup-steps
   cluster-setup-benchmark:
     docker: *compose-ci-docker
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
-      - KUBE_VERSION: 1.11.4
+      - KUBE_VERSION: 1.11.5
       - KUBE_ENV_NAME: benchmark
     steps: *cluster-setup-steps
   deploy-images-1_10:
     docker: *compose-ci-docker
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
-      - KUBE_VERSION: 1.10.5
+      - KUBE_VERSION: 1.10.11
     steps: *deploy-images-steps
   deploy-images-1_11:
     docker: *compose-ci-docker
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
-      - KUBE_VERSION: 1.11.4
+      - KUBE_VERSION: 1.11.5
     steps: *deploy-images-steps
   deploy-images-benchmark:
     docker: *compose-ci-docker
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
-      - KUBE_VERSION: 1.11.4
+      - KUBE_VERSION: 1.11.5
       - KUBE_ENV_NAME: benchmark
     steps: *deploy-images-steps
   test-e2e-1_10:
     docker: *compose-ci-golang
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
-      - KUBE_VERSION: 1.10.5
+      - KUBE_VERSION: 1.10.11
     steps: *test-e2e-steps
   test-e2e-1_11:
     docker: *compose-ci-golang
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
-      - KUBE_VERSION: 1.11.4
+      - KUBE_VERSION: 1.11.5
     steps: *test-e2e-steps
   coverage-upload:
     docker: *compose-ci-golang
@@ -285,7 +285,7 @@ jobs:
     docker: *compose-ci-golang
     working_directory: /root/src/github.com/docker/compose-on-kubernetes    
     environment:
-      - KUBE_VERSION: 1.11.4
+      - KUBE_VERSION: 1.11.5
       - KUBE_ENV_NAME: benchmark
     steps:
       - attach_workspace:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -841,7 +841,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[projects]]
   digest = "1:e762108455a2930c3d35d270c67192f67c4d68135391e29dae2506156c630cd1"
@@ -854,7 +854,7 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[projects]]
   digest = "1:d1cb38288f05c05ab1900a3600a7545837483d4d9dd9268bb352947a47f85ec9"
@@ -910,7 +910,7 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[projects]]
   digest = "1:5c5d0d8da6a2a6b1df8509fefe8bacce11c6f0b3b4f860e4a5344d375404c90c"
@@ -1007,7 +1007,7 @@
     "plugin/pkg/authorizer/webhook",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[projects]]
   digest = "1:3a273c18893721496e09d87704cbbd83d3e6996d7a50e7d1fa47cf7c914c220b"
@@ -1172,7 +1172,7 @@
     "util/retry",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[projects]]
   digest = "1:8347f4a07e009c4199157346c27f02a0cd1ecabf3fab1379400df11ac158185d"
@@ -1185,7 +1185,7 @@
     "pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[projects]]
   branch = "master"
@@ -1237,6 +1237,7 @@
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1beta1",
     "k8s.io/apimachinery/pkg/conversion",
     "k8s.io/apimachinery/pkg/fields",
     "k8s.io/apimachinery/pkg/labels",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,19 +24,19 @@
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[constraint]]
   name = "k8s.io/apiserver"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[constraint]]
   name = "github.com/mitchellh/go-homedir"
@@ -95,15 +95,15 @@
 
 [[override]]
   name = "k8s.io/api"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[override]]
   name = "k8s.io/kubernetes"
-  revision = "v1.11.4"
+  revision = "v1.11.5"
 
 [[override]]
   name = "k8s.io/kube-aggregator"
-  revision = "kubernetes-1.11.4"
+  revision = "kubernetes-1.11.5"
 
 [[override]]
   name = "k8s.io/kube-openapi"


### PR DESCRIPTION
This bumps vendoring of k8s to 1.11.5, and test environments to 1.11.5  and 1.10.11