### PR TITLE
Skip liveness probe option

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -23,6 +23,7 @@ func parseOptions(uninstall *bool, options *install.SafeOptions) *rest.Config {
 	flag.DurationVar(&options.OptionsCommon.ReconciliationInterval, "reconciliation-interval", constants.DefaultFullSyncInterval, "Interval of reconciliation loop")
 	flag.StringVar(&options.OptionsCommon.Tag, "tag", "latest", "Image tag")
 	flag.StringVar(&options.Etcd.Servers, "etcd-servers", "", "etcd server addresses")
+	flag.BoolVar(&options.SkipLivenessProbes, "skip-liveness-probes", false, "Disable liveness probe on Controller and API server deployments. Use this when HTTPS liveness probe fails.")
 
 	flag.StringVar(&etcdCA, "etcd-ca-file", "", "CA of etcd TLS certificate")
 	flag.StringVar(&etcdCert, "etcd-cert-file", "", "TLS client certificate for accessing etcd")

--- a/install/install.go
+++ b/install/install.go
@@ -583,6 +583,9 @@ func (c *installer) createAPIServer(ctx *installerContext) error {
 			},
 		},
 	}
+	if c.commonOptions.SkipLivenessProbes {
+		deploy.Spec.Template.Spec.Containers[0].LivenessProbe = nil
+	}
 
 	applyEtcdOptions(&deploy.Spec.Template.Spec, c.etcdOptions)
 	applyNetworkOptions(&deploy.Spec.Template.Spec, c.networkOptions)
@@ -749,6 +752,10 @@ func (c *installer) createController(ctx *installerContext) error {
 	}
 	if c.enableCoverage {
 		deploy.Spec.Template.Spec.Containers[0].Env = []corev1types.EnvVar{{Name: "TEST_COMPOSE_CONTROLLER", Value: "1"}}
+	}
+
+	if c.commonOptions.SkipLivenessProbes {
+		deploy.Spec.Template.Spec.Containers[0].LivenessProbe = nil
 	}
 
 	shouldDo, err := c.objectFilter.filter(deploy)

--- a/install/safe.go
+++ b/install/safe.go
@@ -156,7 +156,9 @@ func applyNetworkOptions(pod *corev1types.PodSpec, opts *NetworkOptions) {
 			ContainerPort: 9443,
 		})
 		pod.Containers[0].Args = append(pod.Containers[0].Args, "--secure-port", "9443")
-		pod.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(9443)
+		if pod.Containers[0].LivenessProbe != nil {
+			pod.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(9443)
+		}
 		return
 	}
 
@@ -172,7 +174,10 @@ func applyNetworkOptions(pod *corev1types.PodSpec, opts *NetworkOptions) {
 		})
 	}
 	pod.Containers[0].Args = append(pod.Containers[0].Args, fmt.Sprintf("--secure-port=%v", opts.Port))
-	pod.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(int(opts.Port))
+
+	if pod.Containers[0].LivenessProbe != nil {
+		pod.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(int(opts.Port))
+	}
 
 	if opts.CustomTLSBundle == nil {
 		return

--- a/install/types.go
+++ b/install/types.go
@@ -16,6 +16,7 @@ type OptionsCommon struct {
 	DefaultServiceType     string
 	APIServerAffinity      *corev1types.Affinity
 	ControllerAffinity     *corev1types.Affinity
+	SkipLivenessProbes     bool
 }
 
 // UnsafeOptions holds install options for the api extension


### PR DESCRIPTION
On some Managed clusters (I look at you AKS !), https liveness probes fail with error 403.
To mitigate the issue temporary, this add a flag to disable liveness probes.