### PR TITLE
synchronize with code from docker cli

### DIFF
--- a/api/check.go
+++ b/api/check.go
@@ -1,0 +1,55 @@
+package apis
+
+import (
+	apiv1beta1 "github.com/docker/compose-on-kubernetes/api/compose/v1beta1"
+	apiv1beta2 "github.com/docker/compose-on-kubernetes/api/compose/v1beta2"
+	"github.com/pkg/errors"
+	apimachinerymetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+)
+
+// StackVersion represents the detected Compose Component on Kubernetes side.
+type StackVersion string
+
+const (
+	// StackAPIV1Beta1 is returned if it's the most recent version available.
+	StackAPIV1Beta1 = StackVersion("v1beta1")
+	// StackAPIV1Beta2 is returned if it's the most recent version available.
+	StackAPIV1Beta2 = StackVersion("v1beta2")
+)
+
+// GetStackAPIVersion returns the most recent stack API installed.
+func GetStackAPIVersion(clientSet *kubernetes.Clientset) (StackVersion, error) {
+	groups, err := clientSet.Discovery().ServerGroups()
+	if err != nil {
+		return "", err
+	}
+
+	return getAPIVersion(groups)
+}
+
+func getAPIVersion(groups *metav1.APIGroupList) (StackVersion, error) {
+	switch {
+	case findVersion(apiv1beta2.SchemeGroupVersion, groups.Groups):
+		return StackAPIV1Beta2, nil
+	case findVersion(apiv1beta1.SchemeGroupVersion, groups.Groups):
+		return StackAPIV1Beta1, nil
+	default:
+		return "", errors.Errorf("failed to find a Stack API version")
+	}
+}
+
+func findVersion(stackAPI schema.GroupVersion, groups []apimachinerymetav1.APIGroup) bool {
+	for _, group := range groups {
+		if group.Name == stackAPI.Group {
+			for _, version := range group.Versions {
+				if version.Version == stackAPI.Version {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/api/check_test.go
+++ b/api/check_test.go
@@ -1,0 +1,51 @@
+package apis
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetStackAPIVersion(t *testing.T) {
+	var tests = []struct {
+		description   string
+		groups        *metav1.APIGroupList
+		err           bool
+		expectedStack StackVersion
+	}{
+		{"no stack api", makeGroups(), true, ""},
+		{"v1beta1", makeGroups(groupVersion{"compose.docker.com", []string{"v1beta1"}}), false, StackAPIV1Beta1},
+		{"v1beta2", makeGroups(groupVersion{"compose.docker.com", []string{"v1beta2"}}), false, StackAPIV1Beta2},
+		{"most recent has precedence", makeGroups(groupVersion{"compose.docker.com", []string{"v1beta1", "v1beta2"}}), false, StackAPIV1Beta2},
+	}
+
+	for _, test := range tests {
+		version, err := getAPIVersion(test.groups)
+		if test.err {
+			assert.ErrorContains(t, err, "")
+		} else {
+			assert.NilError(t, err)
+		}
+		assert.Check(t, is.Equal(test.expectedStack, version))
+	}
+}
+
+type groupVersion struct {
+	name     string
+	versions []string
+}
+
+func makeGroups(versions ...groupVersion) *metav1.APIGroupList {
+	groups := make([]metav1.APIGroup, len(versions))
+	for i := range versions {
+		groups[i].Name = versions[i].name
+		for _, v := range versions[i].versions {
+			groups[i].Versions = append(groups[i].Versions, metav1.GroupVersionForDiscovery{Version: v})
+		}
+	}
+	return &metav1.APIGroupList{
+		Groups: groups,
+	}
+}

--- a/api/client/clientset/clientset.go
+++ b/api/client/clientset/clientset.go
@@ -7,6 +7,9 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
+
+	// For GKE authentication
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // Interface defines the methods a compose kube client should have

--- a/api/compose/v1beta1/parsing.go
+++ b/api/compose/v1beta1/parsing.go
@@ -1,0 +1,4 @@
+package v1beta1
+
+// MaxComposeVersion is the most recent version of compose file Schema supported in v1beta1
+const MaxComposeVersion = "3.5"

--- a/api/config.go
+++ b/api/config.go
@@ -1,0 +1,26 @@
+package apis
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/homedir"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// NewKubernetesConfig resolves the path to the desired Kubernetes configuration file based on
+// the KUBECONFIG environment variable and command line flags.
+func NewKubernetesConfig(configPath string) clientcmd.ClientConfig {
+	kubeConfig := configPath
+	if kubeConfig == "" {
+		if config := os.Getenv("KUBECONFIG"); config != "" {
+			kubeConfig = config
+		} else {
+			kubeConfig = filepath.Join(homedir.Get(), ".kube/config")
+		}
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfig},
+		&clientcmd.ConfigOverrides{})
+}


### PR DESCRIPTION
Resync with docker cli in order to remove the duplicated code and use compose-on-kubernetes as a dependency.

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>