### PR TITLE
Add ability to change pull policy on install

### DIFF
--- a/cmd/installer/main_test.go
+++ b/cmd/installer/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1types "k8s.io/api/core/v1"
+)
+
+// TestParsePullPolicyValid verifies that parsing a valid pull policy works
+func TestParsePullPolicyValid(t *testing.T) {
+	for _, pp := range []corev1types.PullPolicy{corev1types.PullAlways, corev1types.PullNever, corev1types.PullIfNotPresent} {
+		res, err := parsePullPolicy(string(pp))
+		assert.NoError(t, err)
+		assert.Equal(t, res, pp)
+	}
+}
+
+// TestParsePullPolicyInValid verifies that parsing an invalid pull policy
+// triggers an error
+func TestParsePullPolicyInValid(t *testing.T) {
+	for _, pp := range []string{"always", "invalid", ""} {
+		res, err := parsePullPolicy(string(pp))
+		assert.EqualError(t, err, fmt.Sprintf("invalid pull policy: % q", pp))
+		assert.Empty(t, res)
+	}
+}

--- a/install/install.go
+++ b/install/install.go
@@ -524,7 +524,7 @@ func (c *installer) configureAPIServerImage() (image string, args []string, env 
 			"--service-namespace", c.commonOptions.Namespace,
 		},
 		[]corev1types.EnvVar{},
-		corev1types.PullAlways
+		c.commonOptions.PullPolicy
 }
 
 func (c *installer) createAPIServer(ctx *installerContext) error {
@@ -688,7 +688,7 @@ func (c *installer) configureControllerImage() (image string, args []string, pul
 	return imagePrefix + "controller:" + c.commonOptions.Tag, []string{
 		"--kubeconfig", "",
 		"--reconciliation-interval", c.commonOptions.ReconciliationInterval.String(),
-	}, corev1types.PullAlways
+	}, c.commonOptions.PullPolicy
 }
 
 func (c *installer) createController(ctx *installerContext) error {

--- a/install/types.go
+++ b/install/types.go
@@ -17,6 +17,7 @@ type OptionsCommon struct {
 	APIServerAffinity      *corev1types.Affinity
 	ControllerAffinity     *corev1types.Affinity
 	SkipLivenessProbes     bool
+	PullPolicy             corev1types.PullPolicy
 }
 
 // UnsafeOptions holds install options for the api extension


### PR DESCRIPTION
Allows setting the image pull policy on install using a `-pull-policy` flag. Note that the flag is ignored if installed in debug or coverage modes.

The default pull policy of `Always` is maintained.

Tested manually using the following command against a clean Kubernetes cluster:
```console
$ ./bin/installer -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.16 -skip-liveness-probes=true -pull-policy Never
INFO[0000] Checking installation state                  
INFO[0000] Install image with tag "v0.4.16" in namespace "compose" 
INFO[0000] Api server: image: "docker/kube-compose-dev-api-server:v0.4.16", pullPolicy: "Never" 
INFO[0000] Controller: image: "docker/kube-compose-dev-controller:v0.4.16", pullPolicy: "Never" 

$ kubectl get all -n compose
NAME                                                                  READY   STATUS              RESTARTS   AGE
pod/compose-5b9f95796d-gc7lr                                          0/1     ErrImageNeverPull   0          8s
pod/compose-api-86cccb67cf-xpqmd                                      0/1     ErrImageNeverPull   0          8s
pod/compose-etcd-0000                                                 1/1     Running             0          1m
pod/compose-etcd-0001                                                 1/1     Running             0          59s
pod/compose-etcd-0002                                                 1/1     Running             0          20s
pod/etcd-operator-etcd-operator-etcd-backup-operator-6b58f6899ktz9g   1/1     Running             0          1m
pod/etcd-operator-etcd-operator-etcd-operator-69f56d5647-vvf4c        1/1     Running             0          1m
pod/etcd-operator-etcd-operator-etcd-restore-operator-7b7584d5n6qx8   1/1     Running             0          1m
```