### PR TITLE
Fix Healthchecks for API server

### DIFF
--- a/cmd/compose-controller/main.go
+++ b/cmd/compose-controller/main.go
@@ -133,8 +133,6 @@ func start(opts *controllerOptions) error {
 		log.Infof("Received signal: %v", sig)
 		close(stop)
 	}()
-	healthz.DefaultHealthz()
-	go http.ListenAndServe(":8080", nil)
 	reconcileQueue := deduplication.NewStringChan(reconcileQueueLength)
 	deletionQueue := make(chan *v1beta2.Stack, deletionChannelSize)
 	childrenStore, err := controller.NewChildrenListener(k8sClientSet, *opts.reconciliationInterval.Value(), reconcileQueue.In())
@@ -158,6 +156,9 @@ func start(opts *controllerOptions) error {
 	}
 	stackReconciler.Start(reconcileQueue.Out(), deletionQueue, stop)
 	log.Infof("Controller ready")
+
+	healthz.DefaultHealthz()
+	go http.ListenAndServe(":8080", nil)
 	<-stop
 	return nil
 }

--- a/install/install.go
+++ b/install/install.go
@@ -569,7 +569,8 @@ func (c *installer) createAPIServer(ctx *installerContext) error {
 								Handler: corev1types.Handler{
 									HTTPGet: &corev1types.HTTPGetAction{
 										Path:   "/healthz",
-										Scheme: corev1types.URISchemeHTTPS,
+										Port:   intstr.FromInt(8080),
+										Scheme: corev1types.URISchemeHTTP,
 									},
 								},
 								InitialDelaySeconds: 15,

--- a/install/safe.go
+++ b/install/safe.go
@@ -7,7 +7,6 @@ import (
 	corev1types "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 )
 
@@ -156,9 +155,6 @@ func applyNetworkOptions(pod *corev1types.PodSpec, opts *NetworkOptions) {
 			ContainerPort: 9443,
 		})
 		pod.Containers[0].Args = append(pod.Containers[0].Args, "--secure-port", "9443")
-		if pod.Containers[0].LivenessProbe != nil {
-			pod.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(9443)
-		}
 		return
 	}
 
@@ -174,10 +170,6 @@ func applyNetworkOptions(pod *corev1types.PodSpec, opts *NetworkOptions) {
 		})
 	}
 	pod.Containers[0].Args = append(pod.Containers[0].Args, fmt.Sprintf("--secure-port=%v", opts.Port))
-
-	if pod.Containers[0].LivenessProbe != nil {
-		pod.Containers[0].LivenessProbe.HTTPGet.Port = intstr.FromInt(int(opts.Port))
-	}
 
 	if opts.CustomTLSBundle == nil {
 		return


### PR DESCRIPTION
Previously, the API server exposed its healthz endpoint in HTTPS alongside the APIs it serves. The problem is that with certain setups, the mutual TLS setup between Kube aggregator and the Compose API server made the liveness probe fail with authentication issues.

This PR fixes that by making the API server serve a plain HTTP healthz endpoint separately from the TLS-enabled endpoint, and makes the installer use it.

This will fix #34 and makes it possible to have liveness probes on Azure AKS