### PR TITLE
Add `CGO_ENABLED=0` when building the `installer` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,10 @@ FORCE:
 clean: ## clean the binaries
 	rm -Rf ./bin
 
+bin/installer: cmd/installer FORCE
+	@echo "🌟 $@"
+	@CGO_ENABLED=0 go build $(VERBOSE_GO) $(GOBUILD_FLAGS) -ldflags=$(LDFLAGS) -o $@$(EXEC_EXT) ./$<
+
 bin/%: cmd/% FORCE
 	@echo "🌟 $@"
 	@go build $(VERBOSE_GO) $(GOBUILD_FLAGS) -ldflags=$(LDFLAGS) -o $@$(EXEC_EXT) ./$<


### PR DESCRIPTION
Installer is meant run in the client machine, so it should be compiled with `CGO_ENABLED=0` to avoid libc-musl linking problems.

So this PR just adds an override target to `bin/%` in the case of the `installer`.