### PR TITLE
Add Compose on Kubernetes documentation for minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,4 @@ See the [contributing](./CONTRIBUTING.md) and [debugging](./DEBUGGING.md) guides
 # Deploying Compose on Kubernetes
 
 - Guide for [Azure AKS](./docs/install-on-aks.md).
+- Guide for [Minikube](./docs/install-on-minikube.md).

--- a/docs/deploy-etcd.md
+++ b/docs/deploy-etcd.md
@@ -1,0 +1,28 @@
+## Deploy etcd
+
+### Install Helm server side component
+
+- Create the tiller service account: `kubectl -n kube-system create serviceaccount tiller`.
+- Give it admin access to your cluster (note: you might want to reduce the scope of this): `kubectl -n kube-system create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount 
+kube-system:tiller`.
+- Run `helm init --service-account tiller` to initialize the helm component.
+
+### Deploy etcd operator and create an etcd cluster
+
+- Run `helm install --name etcd-operator stable/etcd-operator --namespace compose` to install the etcd-operator chart.
+- Create an etcd cluster definition like this one in a file named compose-etcd.yaml:
+
+```yaml
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: "compose-etcd"
+  namespace: "compose"
+spec:
+  size: 3
+  version: "3.2.13"
+```
+- Run `kubectl apply -f compose-etcd.yaml`.
+- This should bring an etcd cluster in the `compose` namespace.
+
+**Note: this cluster configuration is really naive and does does not use mutual TLS to authenticate application accessing the data. For enabling mutual TLS, please refer to https://github.com/coreos/etcd-operator** 

--- a/docs/install-on-aks.md
+++ b/docs/install-on-aks.md
@@ -3,45 +3,20 @@
 ## Pre-requisites
 - To install Compose on Kubernetes on Azure AKS, you must create an AKS cluster with RBAC enabled.
 - To install etcd using these instructions, you must have [Helm](https://helm.sh) in your client environment.
-- [Download the Compose on Kubernetes installer](https://github.com/docker/compose-on-kubernetes/releases)
+- [Download the Compose on Kubernetes installer](https://github.com/docker/compose-on-kubernetes/releases).
 
 ## Create compose namespace
 
-Just run `kubectl create namespace compose`
+Just run `kubectl create namespace compose`.
 
 ## Deploy etcd
 
 If you already have an etcd instance, skip this.
-
-### Install Helm server side component
-
-- Create the tiller service account: `kubectl -n kube-system create serviceaccount tiller`
-- Give it admin access to your cluster (note: you might want to reduce the scope of this): `kubectl -n kube-system create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount kube-system:tiller`
-- Run `helm init --service-account tiller` to initialize the helm component.
-
-### Deploy etcd operator and create an etcd cluster
-
-- Run `helm install --name etcd-operator stable/etcd-operator --namespace compose` to install the etcd-operator chart
-- Create an etcd cluster definition like this one in a file named compose-etcd.yaml:
-
-```yaml
-apiVersion: "etcd.database.coreos.com/v1beta2"
-kind: "EtcdCluster"
-metadata:
-  name: "compose-etcd"
-  namespace: "compose"
-spec:
-  size: 3
-  version: "3.2.13"
-```
-- Run `kubectl apply -f compose-etcd.yaml`
-- This should bring an etcd cluster in the `compose` namespace
-
-**Note: this cluster configuration is really naive and does does not use mutual TLS to authenticate application accessing the data. For enabling mutual TLS, please refer to https://github.com/coreos/etcd-operator** 
+Otherwise, please follow [How to deploy etcd](./deploy-etcd.md).
 
 ## Deploy Compose on Kubernetes
 
-Run `installer-[darwin|linux|windows.exe] -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.16 -skip-liveness-probes=true`
+Run `installer-[darwin|linux|windows.exe] -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.16 -skip-liveness-probes=true`.
 
 **Note: There is currently an issue with AKS where the API Server Liveness Probe always fails due to a TLS issue. We'll get in touch with Microsoft to try to solve the issue in the future.**
 

--- a/docs/install-on-minikube.md
+++ b/docs/install-on-minikube.md
@@ -1,0 +1,47 @@
+# Install on Minikube
+
+## Pre-requisites
+- [Minikube](https://github.com/kubernetes/minikube)
+- To install etcd using these instructions, you must have [Helm](https://helm.sh) in your client environment.
+- [Download the Compose on Kubernetes installer](https://github.com/docker/compose-on-kubernetes/releases).
+
+## Create compose namespace
+
+- First you should have the confirmation that everything is running and `kubectl` is pointing to the minikube vm by running `minikube status`.
+If not, please start it by running `minikube start`. That should create and/or start Minikube's VM.
+- Then, create a compose namespace by running `kubectl create namespace compose`.
+
+## Deploy etcd
+
+If you already have an etcd instance, skip this. Otherwise, please follow [How to deploy etcd](./deploy-etcd.md).
+
+## Deploy Compose on Kubernetes
+
+Run `installer-[darwin|linux|windows.exe] -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.16 -skip-liveness-probes=true`.
+
+## Deploy a stack in the cluster
+
+By now you should be able to [Check that Compose on Kubernetes is installed](../README.md#check-that-compose-on-kubernetes-is-installed) and [Deploy a stack](../README.md#deploy-a-stack).
+
+Then when listing Minikube's services with `minikube service list` you should see something like:
+```sh
+$ minikube service list
+|-------------|-----------------------|-----------------------------|
+|  NAMESPACE  |         NAME          |             URL             |
+|-------------|-----------------------|-----------------------------|
+| compose     | compose-api           | No node port                |
+| compose     | compose-etcd          | No node port                |
+| compose     | compose-etcd-client   | No node port                |
+| compose     | etcd-restore-operator | No node port                |
+| default     | db                    | No node port                |
+| default     | kubernetes            | No node port                |
+| default     | web                   | No node port                |
+| default     | web-published         | http://192.168.99.103:32399 |
+| default     | words                 | No node port                |
+| kube-system | kube-dns              | No node port                |
+| kube-system | kubernetes-dashboard  | No node port                |
+| kube-system | tiller-deploy         | No node port                |
+|-------------|-----------------------|-----------------------------|
+```
+
+To access our example web application, please run `minikube service web-published`. This should open a browser pointing to Minikube's VM ip in the service's exposed port. In this case 32399.


### PR DESCRIPTION
Adds documentation on how to install compose on kubernetes in `./docs/install-on-minikube.md` and a link in the `README.md`