### PR TITLE
Update install docs with upcoming v0.4.18 tag

### DIFF
--- a/docs/deploy-etcd.md
+++ b/docs/deploy-etcd.md
@@ -9,6 +9,7 @@ kube-system:tiller`.
 
 ### Deploy etcd operator and create an etcd cluster
 
+- Make sure the `compose` namespace exists on your cluster.
 - Run `helm install --name etcd-operator stable/etcd-operator --namespace compose` to install the etcd-operator chart.
 - Create an etcd cluster definition like this one in a file named compose-etcd.yaml:
 

--- a/docs/install-on-aks.md
+++ b/docs/install-on-aks.md
@@ -16,8 +16,6 @@ Otherwise, please follow [How to deploy etcd](./deploy-etcd.md).
 
 ## Deploy Compose on Kubernetes
 
-Run `installer-[darwin|linux|windows.exe] -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.16 -skip-liveness-probes=true`.
-
-**Note: There is currently an issue with AKS where the API Server Liveness Probe always fails due to a TLS issue. We'll get in touch with Microsoft to try to solve the issue in the future.**
+Run `installer-[darwin|linux|windows.exe] -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.18`.
 
 **Note: To setup Mutual TLS with the etcd instance, you can use `etcd-ca-file`, `etcd-key-file` and `etcd-cert-file` flags.**

--- a/docs/install-on-minikube.md
+++ b/docs/install-on-minikube.md
@@ -17,7 +17,7 @@ If you already have an etcd instance, skip this. Otherwise, please follow [How t
 
 ## Deploy Compose on Kubernetes
 
-Run `installer-[darwin|linux|windows.exe] -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.16 -skip-liveness-probes=true`.
+Run `installer-[darwin|linux|windows.exe] -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.18`.
 
 ## Deploy a stack in the cluster
 


### PR DESCRIPTION
This makes sure docs refer to the latest release, and drop the --skip-liveness-probes flag (as the API server now has a probe exposed in plain HTTP).

Unfortunately, with the new port for the probe, installer v0.4.18 will fail to install version v0.4.17 and earlier without the --skip-liveness-probes flag.