### PR TITLE
Fix the DockerCon EU 2018 hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ e2e: ## Run the e2e tests
 	grep SUCCESS e2e-test-output.txt | grep  -q "$(E2E_EXPECTED_SKIP) Skipped"
 
 e2e-kind: ## Run the e2e tests
-	KUBECONFIG="$(shell kind get kubeconfig-path --name="compose-on-kube")" IMAGE_REPO_PREFIX=$(IMAGE_REPO_PREFIX) ginkgo -v -p e2e/ -- -tag "$(TAG)" 2>&1 | tee e2e-test-output.txt
+	KUBECONFIG="$(shell kind get kubeconfig-path --name="compose-on-kube")" IMAGE_REPO_PREFIX=$(IMAGE_REPO_PREFIX) ginkgo -v -p $(GINKGO_FLAGS) e2e/ -- -tag "$(TAG)" 2>&1 | tee e2e-test-output.txt
 	grep SUCCESS e2e-test-output.txt | grep  -q "$(E2E_EXPECTED_SKIP) Skipped"
 
 e2e-kind-circleci:

--- a/e2e/rbac_test.go
+++ b/e2e/rbac_test.go
@@ -228,17 +228,25 @@ services:
 			},
 		})
 		expectNoError(err)
-		spec := `version: '3.2'
+		_, err = originNS.CreateStack(cluster.StackOperationV1beta2Stack, "by-cluster-admin", `version: '3.2'
 services:
-  back:
-    image: nginx:1.12.1-alpine`
-		_, err = originNS.CreateStack(cluster.StackOperationV1beta2Stack, "by-cluster-admin", spec)
+  back-cluster-admin:
+    image: nginx:1.12.1-alpine`)
 		expectNoError(err)
-		_, err = editor.CreateStack(cluster.StackOperationV1beta2Stack, "by-editor", spec)
+		_, err = editor.CreateStack(cluster.StackOperationV1beta2Stack, "by-editor", `version: '3.2'
+services:
+  back-editor:
+    image: nginx:1.12.1-alpine`)
 		expectNoError(err)
-		_, err = admin.CreateStack(cluster.StackOperationV1beta2Stack, "by-admin", spec)
+		_, err = admin.CreateStack(cluster.StackOperationV1beta2Stack, "by-admin", `version: '3.2'
+services:
+  back-admin:
+    image: nginx:1.12.1-alpine`)
 		expectNoError(err)
-		_, err = viewer.CreateStack(cluster.StackOperationV1beta2Stack, "by-viewer", spec)
+		_, err = viewer.CreateStack(cluster.StackOperationV1beta2Stack, "by-viewer", `version: '3.2'
+services:
+  back-viewer:
+    image: nginx:1.12.1-alpine`)
 		Expect(err).To(HaveOccurred())
 		stacks, err := viewer.ListStacks()
 		expectNoError(err)

--- a/e2e/rbac_test.go
+++ b/e2e/rbac_test.go
@@ -257,5 +257,8 @@ services:
 		stacks, err = admin.ListStacks()
 		expectNoError(err)
 		Expect(stacks).To(HaveLen(3))
+		waitUntil(originNS.IsStackAvailable("by-cluster-admin"))
+		waitUntil(originNS.IsStackAvailable("by-editor"))
+		waitUntil(originNS.IsStackAvailable("by-admin"))
 	})
 })

--- a/internal/controller/resourceupdater.go
+++ b/internal/controller/resourceupdater.go
@@ -20,16 +20,8 @@ type impersonatingResourceUpdaterProvider struct {
 	ownerCache StackOwnerCacher
 }
 
-func (p *impersonatingResourceUpdaterProvider) getUpdaterForMutation(stack *v1beta2.Stack) (resourceUpdater, error) {
-	return p.getUpdater(stack, false)
-}
-
-func (p *impersonatingResourceUpdaterProvider) getUpdaterForDeletion(stack *v1beta2.Stack) (resourceUpdater, error) {
-	return p.getUpdater(stack, true)
-}
-
-func (p *impersonatingResourceUpdaterProvider) getUpdater(stack *v1beta2.Stack, acceptDirtyImpersonation bool) (resourceUpdater, error) {
-	ic := p.ownerCache.get(stack, acceptDirtyImpersonation)
+func (p *impersonatingResourceUpdaterProvider) getUpdater(stack *v1beta2.Stack, isDirty bool) (resourceUpdater, error) {
+	ic := p.ownerCache.get(stack, !isDirty)
 	localConfig := p.config
 	localConfig.Impersonate = ic
 	result := &k8sResourceUpdater{

--- a/internal/controller/stackownercache.go
+++ b/internal/controller/stackownercache.go
@@ -85,7 +85,7 @@ func (s *stackOwnerCache) getWithError(stack *v1beta2.Stack, acceptDirty bool) (
 	}
 	owner, err := s.getter.get(stack)
 	if err != nil {
-		log.Errorf("Unable to get stack owner: %s", err)
+		log.Errorf("Unable to get stack %q owner: %s", objKey, err)
 		if kerrors.IsNotFound(err) {
 			if v, ok := s.data[objKey]; ok {
 				log.Infof("Stack %q seem to have been deleted. Fallback to dirty impersonation config", objKey)

--- a/internal/controller/stackreconciler_test.go
+++ b/internal/controller/stackreconciler_test.go
@@ -49,15 +49,7 @@ type testResourceUpdaterProvider struct {
 	statuses chan<- *v1beta2.Stack
 }
 
-func (p *testResourceUpdaterProvider) getUpdaterForMutation(stack *v1beta2.Stack) (resourceUpdater, error) {
-	return &testResourceUpdater{
-		diffs:    p.diffs,
-		statuses: p.statuses,
-		stack:    stack,
-	}, nil
-}
-
-func (p *testResourceUpdaterProvider) getUpdaterForDeletion(stack *v1beta2.Stack) (resourceUpdater, error) {
+func (p *testResourceUpdaterProvider) getUpdater(stack *v1beta2.Stack, _ bool) (resourceUpdater, error) {
 	return &testResourceUpdater{
 		diffs:    p.diffs,
 		statuses: p.statuses,

--- a/internal/convert/stack.go
+++ b/internal/convert/stack.go
@@ -17,7 +17,8 @@ const (
 	expectedGenerationAnnotation = "com.docker.stack.expected-generation"
 )
 
-func isStackDirty(stack *v1beta2.Stack) bool {
+// IsStackDirty indicates if the stack is pending reconciliation
+func IsStackDirty(stack *v1beta2.Stack) bool {
 	if stack.Status == nil {
 		return true
 	}
@@ -36,7 +37,7 @@ func StackToStack(stack v1beta2.Stack, strategy ServiceStrategy, original *stack
 	if len(composeServices) == 0 {
 		return nil, errors.New("this stack has no service")
 	}
-	stackDirty := isStackDirty(&stack)
+	stackDirty := IsStackDirty(&stack)
 
 	log.Debugf("Stack dirtyness check: %v\nStack object: %#v", stackDirty, stack)
 


### PR DESCRIPTION
This was caused by a very sneaky timing involving
- A stack deletion
- A machine going to sleep at a very bad time
- Etcd compaction happening just after resume

This resulted on the controller somehow missing a "delete" event on a
stack, and attempting to get its owner information in a loop to do some
kind of reconciliation

When we detect that an owner is requested for a stack that is not
present and where its owner is not cached, we let the process panic, to
let the controller be re-scheduled and re-initialized properly with a
full sync