### PR TITLE
Correct the metadata name under compose-etcd.yaml

### DIFF
--- a/docs/deploy-etcd.md
+++ b/docs/deploy-etcd.md
@@ -17,7 +17,7 @@ kube-system:tiller`.
 apiVersion: "etcd.database.coreos.com/v1beta2"
 kind: "EtcdCluster"
 metadata:
-  name: "compose-etcd"
+  name: "compose-etcd-client"
   namespace: "compose"
 spec:
   size: 3


### PR DESCRIPTION
While you use installer script, the README specifies compose-etcd-client, hence it need to match with compose-etcd.yaml file 

```./installer-darwin -namespace=compose -etcd-servers=http://compose-etcd-client:2379 -tag=v0.4.18
INFO[0000] Checking installation state
INFO[0000] Install image with tag "v0.4.18" in namespace "compose"
INFO[0000] Api server: image: "docker/kube-compose-api-server:v0.4.18", pullPolicy: "Always"
INFO[0000] Controller: image: "docker/kube-compose-controller:v0.4.18", pullPolicy: "Always"
```