### PR TITLE
Add Pull Policy support in v1alpha3

### DIFF
--- a/api/compose/v1alpha3/stack.go
+++ b/api/compose/v1alpha3/stack.go
@@ -98,6 +98,7 @@ type ServiceConfig struct {
 	Volumes         []ServiceVolumeConfig    `json:"volumes,omitempty"`
 	WorkingDir      string                   `json:"working_dir,omitempty"`
 	PullSecret      string                   `json:"pull_secret,omitempty"`
+	PullPolicy      string                   `json:"pull_policy,omitempty"`
 }
 
 // ServicePortConfig is the port configuration for a service

--- a/internal/registry/strategyvalidate_test.go
+++ b/internal/registry/strategyvalidate_test.go
@@ -366,3 +366,18 @@ func TestValidateStackNotNilWithoutStatus(t *testing.T) {
 	err := validateStackNotNil()(nil, &stack)
 	assert.Len(t, err, 1)
 }
+
+func TestValidateInvalidPullPolicy(t *testing.T) {
+	s := Stack("test",
+		WithService("redis",
+			Image("redis"),
+			PullPolicy("Invalid")))
+	stack := iv.Stack{
+		Spec: iv.StackSpec{
+			Stack: s.Spec,
+		},
+	}
+	err := validateDryRun()(nil, &stack)
+	assert.Len(t, err, 1)
+	assert.Contains(t, err[0].Error(), `invalid pull policy "Invalid", must be "Always", "IfNotPresent" or "Never"`)
+}

--- a/internal/test/builders/stack.go
+++ b/internal/test/builders/stack.go
@@ -120,6 +120,13 @@ func PullSecret(name string) func(*latest.ServiceConfig) {
 	}
 }
 
+// PullPolicy specifies the pull policy used for this service
+func PullPolicy(policy string) func(*latest.ServiceConfig) {
+	return func(c *latest.ServiceConfig) {
+		c.PullPolicy = policy
+	}
+}
+
 // StopGracePeriod specifies the stop-grace-period duration of a service
 func StopGracePeriod(duration time.Duration) func(*latest.ServiceConfig) {
 	return func(c *latest.ServiceConfig) {


### PR DESCRIPTION
This allows to specify a PullPolicy for each given service in a stack.

This is covered by Unit Tests and a PR will land in Docker CLI to add support for a `x-pull-policy` field in service configs.