### PR TITLE
Make waitUntil report more details on calling site

### DIFF
--- a/e2e/compose_test.go
+++ b/e2e/compose_test.go
@@ -1100,7 +1100,7 @@ func expectNoError(err error) {
 }
 
 func waitUntil(condition wait.ConditionFunc) {
-	expectNoError(wait.PollImmediate(1*time.Second, 5*time.Minute, condition))
+	ExpectWithOffset(1, wait.PollImmediate(1*time.Second, 5*time.Minute, condition)).NotTo(HaveOccurred())
 }
 
 func stackServiceLabel(name string) string {


### PR DESCRIPTION
When a waitUntil fails, we do not get details about where it was called
within the test. That is due to it relying on expectNoError that rewind
only 1 step in the calling stack (thus reporting error call site as
coming from waitUntil).
This PR fix the issue.
