### PR TITLE
Fix: Delete in Foreground propagation crashes controller

### DIFF
--- a/internal/controller/resourceupdater.go
+++ b/internal/controller/resourceupdater.go
@@ -21,13 +21,15 @@ type impersonatingResourceUpdaterProvider struct {
 }
 
 func (p *impersonatingResourceUpdaterProvider) getUpdater(stack *latest.Stack, isDirty bool) (resourceUpdater, error) {
-	ic := p.ownerCache.get(stack, !isDirty)
+	ic, err := p.ownerCache.getWithRetries(stack, !isDirty)
+	if err != nil {
+		return nil, err
+	}
 	localConfig := p.config
 	localConfig.Impersonate = ic
 	result := &k8sResourceUpdater{
 		originalStack: stack,
 	}
-	var err error
 	if result.stackClient, err = clientset.NewForConfig(&localConfig); err != nil {
 		return nil, err
 	}

--- a/internal/controller/stacklistener_test.go
+++ b/internal/controller/stacklistener_test.go
@@ -31,8 +31,8 @@ func (s *dummyOwnerCache) setDirty(key string) {
 	}
 }
 
-func (s *dummyOwnerCache) get(stack *latest.Stack, acceptDirty bool) rest.ImpersonationConfig {
-	return rest.ImpersonationConfig{}
+func (s *dummyOwnerCache) getWithRetries(stack *latest.Stack, acceptDirty bool) (rest.ImpersonationConfig, error) {
+	return rest.ImpersonationConfig{}, nil
 }
 func TestStackListenerCacheInvalidation(t *testing.T) {
 	cache := &dummyOwnerCache{

--- a/internal/controller/stackownercache.go
+++ b/internal/controller/stackownercache.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/docker/compose-on-kubernetes/api/client/clientset"
+	"github.com/docker/compose-on-kubernetes/api/client/clientset/scheme"
 	"github.com/docker/compose-on-kubernetes/api/compose/latest"
 	"github.com/docker/compose-on-kubernetes/internal/stackresources"
 	log "github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 )
@@ -41,7 +43,12 @@ type apiOwnerGetter struct {
 
 func (g *apiOwnerGetter) get(stack *latest.Stack) (*latest.Owner, error) {
 	var owner latest.Owner
-	if err := g.Get().Namespace(stack.Namespace).Name(stack.Name).Resource("stacks").SubResource("owner").Do().Into(&owner); err != nil {
+	if err := g.Get().Namespace(stack.Namespace).Name(stack.Name).
+		Resource("stacks").
+		SubResource("owner").
+		VersionedParams(&metav1.GetOptions{IncludeUninitialized: true}, scheme.ParameterCodec).
+		Do().
+		Into(&owner); err != nil {
 		return nil, err
 	}
 	return &owner, nil

--- a/internal/controller/stackownercache_test.go
+++ b/internal/controller/stackownercache_test.go
@@ -38,19 +38,19 @@ func TestUpdateDeleteSequence(t *testing.T) {
 	testStack.Name = "test"
 	testStack.Namespace = "ns"
 	// as of create
-	cfg := testee.get(testStack, false)
+	cfg, _ := testee.getWithRetries(testStack, false)
 	assert.Equal(t, "test", cfg.UserName)
 	// as of update
 	testee.setDirty(stackresources.ObjKey(testStack.Namespace, testStack.Name))
-	cfg = testee.get(testStack, false)
+	cfg, _ = testee.getWithRetries(testStack, false)
 	assert.Equal(t, "test", cfg.UserName)
 	// as of update followed by delete
 	testee.setDirty(stackresources.ObjKey(testStack.Namespace, testStack.Name))
 	return404 = true
-	cfg = testee.get(testStack, false)
+	cfg, _ = testee.getWithRetries(testStack, false)
 	assert.Equal(t, "test", cfg.UserName)
 	// as of delete
-	cfg = testee.get(testStack, true)
+	cfg, _ = testee.getWithRetries(testStack, true)
 	assert.Equal(t, "test", cfg.UserName)
 	testee.remove(stackresources.ObjKey(testStack.Namespace, testStack.Name))
 
@@ -70,7 +70,6 @@ func TestStackOwnerCachePanicOnUnresolvableOwner(t *testing.T) {
 	testStack := &latest.Stack{}
 	testStack.Name = "test"
 	testStack.Namespace = "ns"
-	assert.Panics(t, func() {
-		testee.get(testStack, true)
-	})
+	_, err := testee.getWithRetries(testStack, true)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
This should fix #75 

This can happen, because depending on the order of the received events, we can need to get the stack owner on an uninitialized stack. This PR makes the owner getter explicitly ask for looking for uninitialized
resources.