### PR TITLE
Fixed typo for function tagForCustomImages

### DIFF
--- a/install/installer.go
+++ b/install/installer.go
@@ -143,7 +143,7 @@ func WithCustomStatusMatch(match func(Status) bool) InstallerOption {
 	}
 }
 
-func tagForCusomImages(controllerImage, apiServerImage string) string {
+func tagForCustomImages(controllerImage, apiServerImage string) string {
 	bytes := sha1.Sum([]byte(fmt.Sprintf("%s %s", controllerImage, apiServerImage)))
 	return hex.EncodeToString(bytes[:])
 }
@@ -159,7 +159,7 @@ func newInstaller(config *rest.Config, options ...InstallerOption) (*installer, 
 	}
 	if i.controllerImageOverride != "" && i.apiServerImageOverride != "" {
 		// compute a tag for these images
-		i.commonOptions.Tag = tagForCusomImages(i.controllerImageOverride, i.apiServerImageOverride)
+		i.commonOptions.Tag = tagForCustomImages(i.controllerImageOverride, i.apiServerImageOverride)
 	}
 	if i.debugImages {
 		i.commonOptions.Tag = "debug"

--- a/install/installer_test.go
+++ b/install/installer_test.go
@@ -7,6 +7,6 @@ import (
 )
 
 func TestGenTagShouldOuptutAtMost63Chars(t *testing.T) {
-	res := tagForCusomImages("foo", "bar")
+	res := tagForCustomImages("foo", "bar")
 	assert.True(t, len(res) <= 63, "%d is too long for a kubernetes label", len(res))
 }


### PR DESCRIPTION
Fix:
	Updated Name for function `tagForCusomImages` to
	`tagForCustomImages` in install/installer.go and the
	respective test.