### PR TITLE
Bump golang, alpine

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -1,8 +1,8 @@
 include common.mk
 
-BUILD_BASE_IMAGE = golang:1.11.1-alpine3.8
-TEST_BASE_IMAGE = golang:1.11.1
-RUN_BASE_IMAGE = alpine:3.8
+BUILD_BASE_IMAGE = golang:1.12.1-alpine3.9
+TEST_BASE_IMAGE = golang:1.12.1
+RUN_BASE_IMAGE = alpine:3.9.2
 KUBERNETES_VERSION ?= 1.13.3
 KIND_TAG = v$(KUBERNETES_VERSION)-$(TAG)
 IMAGES = ${IMAGE_REPO_PREFIX}controller ${IMAGE_REPO_PREFIX}controller-coverage ${IMAGE_REPO_PREFIX}e2e-tests ${IMAGE_REPO_PREFIX}e2e-benchmark ${IMAGE_REPO_PREFIX}api-server ${IMAGE_REPO_PREFIX}api-server-coverage ${IMAGE_REPO_PREFIX}installer


### PR DESCRIPTION
This bumps golang to version 1.12.1 and alpine to 3.9.2