### PR TITLE
Replace AddGeneratedConversionFuncs with AddConversionFuncs

### DIFF
--- a/api/compose/v1alpha3/conversion_generated.go
+++ b/api/compose/v1alpha3/conversion_generated.go
@@ -33,7 +33,7 @@ func init() {
 // RegisterConversions adds conversion functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterConversions(scheme *runtime.Scheme) error {
-	return scheme.AddGeneratedConversionFuncs(
+	return scheme.AddConversionFuncs(
 		Convert_v1alpha3_ComposeFile_To_v1beta2_ComposeFile,
 		Convert_v1beta2_ComposeFile_To_v1alpha3_ComposeFile,
 		Convert_v1alpha3_ConfigObjConfig_To_v1beta2_ConfigObjConfig,

--- a/internal/conversions/v1alpha3.go
+++ b/internal/conversions/v1alpha3.go
@@ -16,7 +16,7 @@ import (
 // RegisterV1alpha3Conversions adds conversion functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterV1alpha3Conversions(scheme *runtime.Scheme) error {
-	return scheme.AddGeneratedConversionFuncs(
+	return scheme.AddConversionFuncs(
 		ownerToInternalV1alpha3,
 		ownerFromInternalV1alpha3,
 		stackToInternalV1alpha3,

--- a/internal/conversions/v1beta1.go
+++ b/internal/conversions/v1beta1.go
@@ -11,7 +11,7 @@ import (
 // Public to allow building arbitrary schemes.
 func RegisterV1beta1Conversions(scheme *runtime.Scheme) error {
 
-	return scheme.AddGeneratedConversionFuncs(
+	return scheme.AddConversionFuncs(
 		ownerToInternalV1beta1,
 		ownerFromInternalV1beta1,
 		stackToInternalV1beta1,

--- a/internal/conversions/v1beta2.go
+++ b/internal/conversions/v1beta2.go
@@ -11,7 +11,7 @@ import (
 // RegisterV1beta2Conversions adds conversion functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterV1beta2Conversions(scheme *runtime.Scheme) error {
-	return scheme.AddGeneratedConversionFuncs(
+	return scheme.AddConversionFuncs(
 		ownerToInternalV1beta2,
 		ownerFromInternalV1beta2,
 		stackToInternalV1beta2,


### PR DESCRIPTION
`AddGeneratedConversionFuncs` is deprecated, replace it with `AddConversionFuncs`.