### PR TITLE
Bump kind image to kube 1.14.0-rc.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   kube_versions:
     - kube_1_11: &kube_1_11 "1.11.7"
     - kube_1_13: &kube_1_13 "1.13.3"
-    - kube_1_14: &kube_1_14 "1.14.0-beta.1"
+    - kube_1_14: &kube_1_14 "1.14.0-rc.1"
   docker-login: &docker-login
     username: $DOCKER_USER
     password: $DOCKER_PASS


### PR DESCRIPTION
Use kube 1.14.0-rc.1 kind node image in CI tests.
Fixes #89 