### PR TITLE
Bump Go version for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ aliases:
     - image: dockereng/kube-compose-ci-golang
       auth: *docker-login
   public-golang: &public-golang
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.12.1
       user: root
 
   e2e-kind-steps: &e2e-kind-steps


### PR DESCRIPTION
Bump the version of Go used by the CI to 1.12.1.