### PR TITLE
Skip flaky bind mount test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ BINARIES = bin/compose-controller bin/api-server bin/installer bin/reconciliatio
 TEST_PACKAGES := ${shell go list ./internal/... ./cmd/... ./api/... ./install/... | grep -v "_generated" | sed 's,github.com/docker/compose-on-kubernetes/,,' | uniq}
 # Number of tests we expect to be skipped in e2e suite. Rule will fail if mismatch.
 # We currently expect the two volume tests to fail on cluster without a default
-# dynamic volume provisioner ('kubectl get storageclass' to check).
-E2E_EXPECTED_SKIP ?= 2
+# dynamic volume provisioner ('kubectl get storageclass' to check) along with
+# the bind mount test which has been reported flaky.
+E2E_EXPECTED_SKIP ?= 3
 
 VERBOSE_GO :=
 ifeq ($(VERBOSE),true)

--- a/e2e/compose_test.go
+++ b/e2e/compose_test.go
@@ -875,6 +875,7 @@ services
 	})
 
 	It("Should support bind volumes", func() {
+		Skip("FIXME (chris-crone): Flaky test")
 		_, err := ns.CreateStack(defaultStrategy, "app", `version: "3.4"
 services:
   test:


### PR DESCRIPTION
The bind mount test has been reported flaky. This PR skips it with a FIXME message.