### PR TITLE
Fix BuildKit Dockerfile

### DIFF
--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -21,7 +21,7 @@ ARG VERSION
 ARG IMAGE_REPO_PREFIX
 ENV GITCOMMIT=$GITCOMMIT VERSION=$VERSION BUILDTIME=$BUILDTIME IMAGE_REPO_PREFIX=$IMAGE_REPO_PREFIX
 ENV CGO_ENABLED=0
-RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test
+RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test bin/e2e_benchmark
 RUN go get github.com/onsi/ginkgo/ginkgo
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl && \
   chmod +x ./kubectl && \
@@ -35,6 +35,12 @@ ENTRYPOINT ["/ginkgo","-v", "-p", "--nodes=10", "/e2e.test", "--"]
 COPY --from=build /go/bin/ginkgo /ginkgo
 COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/e2e/e2e.test /e2e.test
 COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/e2e/retrieve-coverage /retrieve-coverage
+COPY --from=build /bin/kubectl /bin/kubectl
+
+# e2e-benchmark
+FROM runbase AS compose-e2e-benchmark
+ENTRYPOINT ["/e2e_benchmark", "--kubeconfig=/kind-config", "--"]
+COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/bin/e2e_benchmark /e2e_benchmark
 COPY --from=build /bin/kubectl /bin/kubectl
 
 # compose-installer (retrieved with --target=compose-installer)


### PR DESCRIPTION
The BuildKit Dockerfile (used for local development) was broken. Here is a run with the PR on my local machine:
```
make -f docker.Makefile images                                                                                                                                                                                                                                                                                           [19:42:56] 
🌟 build docker/kube-compose-dev-controller:latest
[+] Building 62.6s (19/19) FINISHED                                                                                                                                                                                                                                                                                                                                         
 => [internal] load remote build context                                                                                                                                                                                                                                                                                                                               0.0s
 => copy /context /                                                                                                                                                                                                                                                                                                                                                    0.7s
 => resolve image config for docker.io/docker/dockerfile-upstream:1.0.1-experimental                                                                                                                                                                                                                                                                                   1.3s
 => CACHED docker-image://docker.io/docker/dockerfile-upstream:1.0.1-experimental@sha256:2220efe9582e00cd8f6bbee8f4566e34d7f0388c0e10f2b20499cc19ddd140d8                                                                                                                                                                                                              0.0s
 => CACHED [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                 0.0s
 => [internal] extracting build context                                                                                                                                                                                                                                                                                                                                1.8s
 => [internal] load metadata for docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                             0.0s 
 => [build 1/6] FROM docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                                         0.0s 
 => [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                        0.0s 
 => [runbase 1/2] FROM docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                                  0.0s 
 => CACHED [build 2/6] RUN apk add --no-cache   coreutils   make   git   curl                                                                                                                                                                                                                                                                                          0.0s 
 => [build 3/6] COPY . .                                                                                                                                                                                                                                                                                                                                               1.4s
 => [build 4/6] RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test bin/e2e_benchmark                                                                                                                                                                      37.5s
 => [build 5/6] RUN go get github.com/onsi/ginkgo/ginkgo                                                                                                                                                                                                                                                                                                              12.9s 
 => [build 6/6] RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl &&   chmod +x ./kubectl &&   mv ./kubectl /bin/kubectl                                                                                                                                                                                          3.1s 
 => CACHED [runbase 2/2] RUN apk add ca-certificates --no-cache                                                                                                                                                                                                                                                                                                        0.0s 
 => [stage-8 1/1] COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/bin/compose-controller /compose-controller                                                                                                                                                                                                                                         1.8s 
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 0.3s 
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                0.3s 
 => => writing image sha256:a79f27cb58c218dcd4b787f10497eb53c9c7237a849719047a538bc2e9ae6123                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/docker/kube-compose-dev-controller:latest                                                                                                                                                                                                                                                                                                   0.0s
🌟 build docker/kube-compose-dev-controller-coverage:latest
[+] Building 3.0s (20/20) FINISHED                                                                                                                                                                                                                                                                                                                                          
 => CACHED [internal] load remote build context                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED copy /context /                                                                                                                                                                                                                                                                                                                                             0.0s
 => resolve image config for docker.io/docker/dockerfile-upstream:1.0.1-experimental                                                                                                                                                                                                                                                                                   0.7s
 => CACHED docker-image://docker.io/docker/dockerfile-upstream:1.0.1-experimental@sha256:2220efe9582e00cd8f6bbee8f4566e34d7f0388c0e10f2b20499cc19ddd140d8                                                                                                                                                                                                              0.0s
 => CACHED [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                 0.0s
 => CACHED [internal] extracting build context                                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                        0.0s
 => [build 1/6] FROM docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                                         0.0s
 => [runbase 1/2] FROM docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [build 2/6] RUN apk add --no-cache   coreutils   make   git   curl                                                                                                                                                                                                                                                                                          0.0s
 => CACHED [build 3/6] COPY . .                                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 4/6] RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test bin/e2e_benchmark                                                                                                                                                                0.0s
 => CACHED [build 5/6] RUN go get github.com/onsi/ginkgo/ginkgo                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 6/6] RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl &&   chmod +x ./kubectl &&   mv ./kubectl /bin/kubectl                                                                                                                                                                                   0.0s
 => CACHED [runbase 2/2] RUN apk add ca-certificates --no-cache                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [compose-controller-coverage 1/2] ADD e2e/compose-controller-coverage /                                                                                                                                                                                                                                                                                     0.0s
 => [compose-controller-coverage 2/2] COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/bin/compose-controller.test /compose-controller.test                                                                                                                                                                                                           0.8s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 0.3s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                0.3s
 => => writing image sha256:cf322a9b08eda37fc4964b4292cd75c1dfdd01de35f953980718bad4af52ed9e                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/docker/kube-compose-dev-controller-coverage:latest                                                                                                                                                                                                                                                                                          0.0s
🌟 build docker/kube-compose-dev-e2e-tests:latest
[+] Building 5.5s (23/23) FINISHED                                                                                                                                                                                                                                                                                                                                          
 => CACHED [internal] load remote build context                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED copy /context /                                                                                                                                                                                                                                                                                                                                             0.0s
 => resolve image config for docker.io/docker/dockerfile-upstream:1.0.1-experimental                                                                                                                                                                                                                                                                                   0.6s
 => CACHED docker-image://docker.io/docker/dockerfile-upstream:1.0.1-experimental@sha256:2220efe9582e00cd8f6bbee8f4566e34d7f0388c0e10f2b20499cc19ddd140d8                                                                                                                                                                                                              0.0s
 => CACHED [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                 0.0s
 => CACHED [internal] extracting build context                                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                             0.0s
 => [build 1/6] FROM docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                        0.0s
 => [runbase 1/2] FROM docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [build 2/6] RUN apk add --no-cache   coreutils   make   git   curl                                                                                                                                                                                                                                                                                          0.0s
 => CACHED [build 3/6] COPY . .                                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 4/6] RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test bin/e2e_benchmark                                                                                                                                                                0.0s
 => CACHED [build 5/6] RUN go get github.com/onsi/ginkgo/ginkgo                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 6/6] RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl &&   chmod +x ./kubectl &&   mv ./kubectl /bin/kubectl                                                                                                                                                                                   0.0s
 => CACHED [runbase 2/2] RUN apk add ca-certificates --no-cache                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [compose-e2e-tests 1/5] RUN apk add jq --no-cache                                                                                                                                                                                                                                                                                                           0.0s
 => CACHED [compose-e2e-tests 2/5] COPY --from=build /go/bin/ginkgo /ginkgo                                                                                                                                                                                                                                                                                            0.0s
 => [compose-e2e-tests 3/5] COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/e2e/e2e.test /e2e.test                                                                                                                                                                                                                                                   0.7s
 => [compose-e2e-tests 4/5] COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/e2e/retrieve-coverage /retrieve-coverage                                                                                                                                                                                                                                 0.9s
 => [compose-e2e-tests 5/5] COPY --from=build /bin/kubectl /bin/kubectl                                                                                                                                                                                                                                                                                                1.1s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 0.5s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                0.5s
 => => writing image sha256:4ccbeda7ab07ea1564f6a86255b1d06932b7d5854e41fc4f68eed9eee99d7423                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/docker/kube-compose-dev-e2e-tests:latest                                                                                                                                                                                                                                                                                                    0.0s
🌟 build docker/kube-compose-dev-e2e-benchmark:latest
[+] Building 4.0s (20/20) FINISHED                                                                                                                                                                                                                                                                                                                                          
 => CACHED [internal] load remote build context                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED copy /context /                                                                                                                                                                                                                                                                                                                                             0.0s
 => resolve image config for docker.io/docker/dockerfile-upstream:1.0.1-experimental                                                                                                                                                                                                                                                                                   0.5s
 => CACHED docker-image://docker.io/docker/dockerfile-upstream:1.0.1-experimental@sha256:2220efe9582e00cd8f6bbee8f4566e34d7f0388c0e10f2b20499cc19ddd140d8                                                                                                                                                                                                              0.0s
 => CACHED [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                 0.0s
 => CACHED [internal] extracting build context                                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                             0.0s
 => [build 1/6] FROM docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                        0.0s
 => [runbase 1/2] FROM docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [build 2/6] RUN apk add --no-cache   coreutils   make   git   curl                                                                                                                                                                                                                                                                                          0.0s
 => CACHED [build 3/6] COPY . .                                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 4/6] RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test bin/e2e_benchmark                                                                                                                                                                0.0s
 => CACHED [build 5/6] RUN go get github.com/onsi/ginkgo/ginkgo                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 6/6] RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl &&   chmod +x ./kubectl &&   mv ./kubectl /bin/kubectl                                                                                                                                                                                   0.0s
 => CACHED [runbase 2/2] RUN apk add ca-certificates --no-cache                                                                                                                                                                                                                                                                                                        0.0s
 => [compose-e2e-benchmark 1/2] COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/bin/e2e_benchmark /e2e_benchmark                                                                                                                                                                                                                                     0.6s
 => [compose-e2e-benchmark 2/2] COPY --from=build /bin/kubectl /bin/kubectl                                                                                                                                                                                                                                                                                            1.2s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 0.4s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                0.4s
 => => writing image sha256:64eec069f535044cee70e66c70d21945731e791d343507f920ebc57900211616                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/docker/kube-compose-dev-e2e-benchmark:latest                                                                                                                                                                                                                                                                                                0.0s
🌟 build docker/kube-compose-dev-api-server:latest
[+] Building 3.3s (19/19) FINISHED                                                                                                                                                                                                                                                                                                                                          
 => CACHED [internal] load remote build context                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED copy /context /                                                                                                                                                                                                                                                                                                                                             0.0s
 => resolve image config for docker.io/docker/dockerfile-upstream:1.0.1-experimental                                                                                                                                                                                                                                                                                   0.5s
 => CACHED docker-image://docker.io/docker/dockerfile-upstream:1.0.1-experimental@sha256:2220efe9582e00cd8f6bbee8f4566e34d7f0388c0e10f2b20499cc19ddd140d8                                                                                                                                                                                                              0.0s
 => CACHED [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                 0.0s
 => CACHED [internal] extracting build context                                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                        0.0s
 => [runbase 1/2] FROM docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                                  0.0s
 => [build 1/6] FROM docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                                         0.0s
 => CACHED [build 2/6] RUN apk add --no-cache   coreutils   make   git   curl                                                                                                                                                                                                                                                                                          0.0s
 => CACHED [build 3/6] COPY . .                                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 4/6] RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test bin/e2e_benchmark                                                                                                                                                                0.0s
 => CACHED [build 5/6] RUN go get github.com/onsi/ginkgo/ginkgo                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 6/6] RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl &&   chmod +x ./kubectl &&   mv ./kubectl /bin/kubectl                                                                                                                                                                                   0.0s
 => CACHED [runbase 2/2] RUN apk add ca-certificates --no-cache                                                                                                                                                                                                                                                                                                        0.0s
 => [compose-api-server 1/1] COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/bin/api-server /api-server                                                                                                                                                                                                                                              0.7s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 1.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                0.9s
 => => writing image sha256:b66f263a342281712c20307333b4384bfecb9e940a5e1ea7860d56cddbfd2b9e                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/docker/kube-compose-dev-api-server:latest                                                                                                                                                                                                                                                                                                   0.0s
🌟 build docker/kube-compose-dev-api-server-coverage:latest
[+] Building 3.5s (20/20) FINISHED                                                                                                                                                                                                                                                                                                                                          
 => CACHED [internal] load remote build context                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED copy /context /                                                                                                                                                                                                                                                                                                                                             0.0s
 => resolve image config for docker.io/docker/dockerfile-upstream:1.0.1-experimental                                                                                                                                                                                                                                                                                   0.5s
 => CACHED docker-image://docker.io/docker/dockerfile-upstream:1.0.1-experimental@sha256:2220efe9582e00cd8f6bbee8f4566e34d7f0388c0e10f2b20499cc19ddd140d8                                                                                                                                                                                                              0.0s
 => CACHED [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                 0.0s
 => CACHED [internal] extracting build context                                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                             0.0s
 => [build 1/6] FROM docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                        0.0s
 => [runbase 1/2] FROM docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [runbase 2/2] RUN apk add ca-certificates --no-cache                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 2/6] RUN apk add --no-cache   coreutils   make   git   curl                                                                                                                                                                                                                                                                                          0.0s
 => CACHED [build 3/6] COPY . .                                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 4/6] RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test bin/e2e_benchmark                                                                                                                                                                0.0s
 => CACHED [build 5/6] RUN go get github.com/onsi/ginkgo/ginkgo                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 6/6] RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl &&   chmod +x ./kubectl &&   mv ./kubectl /bin/kubectl                                                                                                                                                                                   0.0s
 => [compose-api-server-coverage 1/2] ADD e2e/api-server-coverage /                                                                                                                                                                                                                                                                                                    0.7s
 => [compose-api-server-coverage 2/2] COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/bin/api-server.test /api-server.test                                                                                                                                                                                                                           1.1s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 0.3s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                0.3s
 => => writing image sha256:b15520586b499a9a746d127a21ae0a235523233ebb57a0c0433730b5c11ae73e                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/docker/kube-compose-dev-api-server-coverage:latest                                                                                                                                                                                                                                                                                          0.0s
🌟 build docker/kube-compose-dev-installer:latest
[+] Building 2.8s (19/19) FINISHED                                                                                                                                                                                                                                                                                                                                          
 => CACHED [internal] load remote build context                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED copy /context /                                                                                                                                                                                                                                                                                                                                             0.0s
 => resolve image config for docker.io/docker/dockerfile-upstream:1.0.1-experimental                                                                                                                                                                                                                                                                                   0.5s
 => CACHED docker-image://docker.io/docker/dockerfile-upstream:1.0.1-experimental@sha256:2220efe9582e00cd8f6bbee8f4566e34d7f0388c0e10f2b20499cc19ddd140d8                                                                                                                                                                                                              0.0s
 => CACHED [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                 0.0s
 => CACHED [internal] extracting build context                                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                        0.0s
 => [build 1/6] FROM docker.io/library/golang:1.12.5-alpine3.9                                                                                                                                                                                                                                                                                                         0.0s
 => [internal] helper image for file operations                                                                                                                                                                                                                                                                                                                        0.0s
 => [runbase 1/2] FROM docker.io/library/alpine:3.9.4                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [build 2/6] RUN apk add --no-cache   coreutils   make   git   curl                                                                                                                                                                                                                                                                                          0.0s
 => CACHED [build 3/6] COPY . .                                                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 4/6] RUN --mount=target=/root/.cache,type=cache make bin/compose-controller bin/compose-controller.test e2e-binary bin/installer bin/api-server bin/api-server.test bin/e2e_benchmark                                                                                                                                                                0.0s
 => CACHED [build 5/6] RUN go get github.com/onsi/ginkgo/ginkgo                                                                                                                                                                                                                                                                                                        0.0s
 => CACHED [build 6/6] RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl &&   chmod +x ./kubectl &&   mv ./kubectl /bin/kubectl                                                                                                                                                                                   0.0s
 => CACHED [runbase 2/2] RUN apk add ca-certificates --no-cache                                                                                                                                                                                                                                                                                                        0.0s
 => [compose-installer 1/1] COPY --from=build /go/src/github.com/docker/compose-on-kubernetes/bin/installer /installer                                                                                                                                                                                                                                                 0.8s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 0.2s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                0.2s
 => => writing image sha256:441fc7b97ca96acb958e90d5889e3f1841a9504c60875b09a4e403badce461bb                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/docker/kube-compose-dev-installer:latest                                                                                                                                                                                                                                                                                                    0.0s
docker/kube-compose-dev-controller docker/kube-compose-dev-controller-coverage docker/kube-compose-dev-e2e-tests docker/kube-compose-dev-e2e-benchmark docker/kube-compose-dev-api-server docker/kube-compose-dev-api-server-coverage docker/kube-compose-dev-installer
```