### PR TITLE
Fix bind mount test

### DIFF
--- a/e2e/compose_test.go
+++ b/e2e/compose_test.go
@@ -882,7 +882,7 @@ services:
     command:
     - /bin/sh
     - -c
-    - "cat /tmp/hostetc/host.conf ; sleep 3600"
+    - "ls /tmp/hostetc/ ; sleep 3600"
     volumes:
       - type: bind
         source: /etc
@@ -895,7 +895,7 @@ services:
 		data, err := ioutil.ReadAll(s)
 		expectNoError(err)
 		sdata := string(data)
-		Expect(strings.Contains(sdata, "order")).To(BeTrue())
+		Expect(strings.Contains(sdata, "hosts")).To(BeTrue())
 	})
 
 	It("Should support volumes", func() {


### PR DESCRIPTION
The previous iteration of this test required specific data in the `/etc/host.conf` file. This is not robust across distributions. As the test just needs to ensure that we have successfully bind mounted a host folder, we now just list its contents and check for the hosts file.

Replaces https://github.com/docker/compose-on-kubernetes/pull/110.