### PR TITLE
Bump kind to v0.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@ version: 2
 
 aliases:
   kube_versions:
-    - kube_1_11: &kube_1_11 "1.11.7"
-    - kube_1_13: &kube_1_13 "1.13.3"
-    - kube_1_14: &kube_1_14 "1.14.1"
+    - kube_1_11: &kube_1_11 "1.11.10"
+    - kube_1_13: &kube_1_13 "1.13.7"
+    - kube_1_14: &kube_1_14 "1.14.3"
   docker-login: &docker-login
     username: $DOCKER_USER
     password: $DOCKER_PASS
@@ -28,7 +28,8 @@ aliases:
         command: |
           git clone https://github.com/kubernetes-sigs/kind.git /root/src/sigs.k8s.io/kind
           cd /root/src/sigs.k8s.io/kind
-          git reset --hard 302bb7dbb611236aeadd6d1741c9f237d1ec28d2
+          git reset --hard cb35e540987e58257c842aaeef0fee350d8967fb
+          GO111MODULE=on go mod vendor
           go install
           cd -
           export PATH="$PATH:/root/bin"
@@ -37,9 +38,9 @@ aliases:
           export IMAGE_PREFIX=kube-compose-
           export IMAGE_REPO_PREFIX=${IMAGE_REPOSITORY:-dockereng}/${IMAGE_PREFIX}
           export KUBERNETES_VERSION_PARAM="${KUBERNETES_VERSION:+KUBERNETES_VERSION=$KUBERNETES_VERSION}"
-          mkdir -p ./pre-loaded-images
-          cp /root/kube-compose-api-server-coverage.tar /root/kube-compose-controller-coverage.tar ./pre-loaded-images/
-          make -f docker.Makefile ${KUBERNETES_VERSION_PARAM} TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} create-kind-cluster
+          make -f docker.Makefile ${KUBERNETES_VERSION_PARAM} create-kind-cluster
+          make -f docker.Makefile IMAGE_ARCHIVE=/root/kube-compose-api-server-coverage.tar load-kind-image-archive
+          make -f docker.Makefile IMAGE_ARCHIVE=/root/kube-compose-controller-coverage.tar load-kind-image-archive
           docker load -i /root/kube-compose-e2e-tests.tar
           make TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} e2e-kind-circleci
         no_output_timeout: 15m
@@ -58,7 +59,8 @@ aliases:
         command: |
           git clone https://github.com/kubernetes-sigs/kind.git /root/src/sigs.k8s.io/kind
           cd /root/src/sigs.k8s.io/kind
-          git reset --hard 302bb7dbb611236aeadd6d1741c9f237d1ec28d2
+          git reset --hard cb35e540987e58257c842aaeef0fee350d8967fb
+          GO111MODULE=on go mod vendor
           go install
           cd -
           export PATH="$PATH:/root/bin"
@@ -67,9 +69,9 @@ aliases:
           export IMAGE_PREFIX=kube-compose-
           export IMAGE_REPO_PREFIX=${IMAGE_REPOSITORY:-dockereng}/${IMAGE_PREFIX}
           export KUBERNETES_VERSION_PARAM="${KUBERNETES_VERSION:+KUBERNETES_VERSION=$KUBERNETES_VERSION}"
-          mkdir -p ./pre-loaded-images
-          cp /root/kube-compose-api-server.tar /root/kube-compose-controller.tar ./pre-loaded-images/
-          make -f docker.Makefile ${KUBERNETES_VERSION_PARAM} TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} create-kind-cluster
+          make -f docker.Makefile ${KUBERNETES_VERSION_PARAM} create-kind-cluster
+          make -f docker.Makefile IMAGE_ARCHIVE=/root/kube-compose-api-server-coverage.tar load-kind-image-archive
+          make -f docker.Makefile IMAGE_ARCHIVE=/root/kube-compose-controller-coverage.tar load-kind-image-archive
           docker load -i /root/kube-compose-e2e-benchmark.tar
           make TAG=${CIRCLE_TAG:-${CIRCLE_SHA1}} e2e-benchmark-kind-circleci
         no_output_timeout: 15m
@@ -185,6 +187,7 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_11
+      KIND_VERSION: "0.4.0"
     steps: *e2e-kind-steps
   e2e-kind-1_13:
     docker: *public-golang
@@ -192,6 +195,7 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_13
+      KIND_VERSION: "0.4.0"
     steps: *e2e-kind-steps
   e2e-kind-1_14:
     docker: *public-golang
@@ -199,13 +203,14 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_14
+      KIND_VERSION: "0.4.0"
     steps: *e2e-kind-steps
   e2e-benchmark-kind:
     docker: *public-golang
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
-      KUBERNETES_VERSION: "1.13.3"
+      KUBERNETES_VERSION: *kube_1_13
     steps: *e2e-benchmark-kind-steps
   test-unit:
     docker: *public-golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ aliases:
     - kube_1_13: &kube_1_13 "1.13.7"
     - kube_1_14: &kube_1_14 "1.14.3"
     - kube_1_15: &kube_1_15 "1.15.0"
+  kind_version: &kind_version "0.4.0"
   docker-login: &docker-login
     username: $DOCKER_USER
     password: $DOCKER_PASS
@@ -188,7 +189,7 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_11
-      KIND_VERSION: "0.4.0"
+      KIND_VERSION: *kind_version
     steps: *e2e-kind-steps
   e2e-kind-1_13:
     docker: *public-golang
@@ -196,7 +197,7 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_13
-      KIND_VERSION: "0.4.0"
+      KIND_VERSION: *kind_version
     steps: *e2e-kind-steps
   e2e-kind-1_14:
     docker: *public-golang
@@ -204,7 +205,7 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_14
-      KIND_VERSION: "0.4.0"
+      KIND_VERSION: *kind_version
     steps: *e2e-kind-steps
   e2e-kind-1_15:
     docker: *public-golang
@@ -212,7 +213,7 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_15
-      KIND_VERSION: "0.4.0"
+      KIND_VERSION: *kind_version
     steps: *e2e-kind-steps
   e2e-benchmark-kind:
     docker: *public-golang
@@ -220,6 +221,7 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_13
+      KIND_VERSION: *kind_version
     steps: *e2e-benchmark-kind-steps
   test-unit:
     docker: *public-golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ aliases:
     - kube_1_11: &kube_1_11 "1.11.10"
     - kube_1_13: &kube_1_13 "1.13.7"
     - kube_1_14: &kube_1_14 "1.14.3"
+    - kube_1_15: &kube_1_15 "1.15.0"
   docker-login: &docker-login
     username: $DOCKER_USER
     password: $DOCKER_PASS
@@ -203,6 +204,14 @@ jobs:
     environment:
       GOPATH: "/root"
       KUBERNETES_VERSION: *kube_1_14
+      KIND_VERSION: "0.4.0"
+    steps: *e2e-kind-steps
+  e2e-kind-1_15:
+    docker: *public-golang
+    working_directory: /root/src/github.com/docker/compose-on-kubernetes
+    environment:
+      GOPATH: "/root"
+      KUBERNETES_VERSION: *kube_1_15
       KIND_VERSION: "0.4.0"
     steps: *e2e-kind-steps
   e2e-benchmark-kind:
@@ -433,6 +442,14 @@ workflows:
               only: /v.*/
             branches:
               only: /^(?!pull\/).*$/
+      - e2e-kind-1_15:
+          requires:
+            - images
+          filters:
+            tags:
+              only: /v.*/
+            branches:
+              only: /^(?!pull\/).*$/
       # - e2e-benchmark-kind:
       #     requires:
       #       - images
@@ -447,6 +464,7 @@ workflows:
             - e2e-kind-1_11
             - e2e-kind-1_13
             - e2e-kind-1_14
+            - e2e-kind-1_15
             # - e2e-benchmark-kind
           filters:
             tags:
@@ -458,6 +476,7 @@ workflows:
             - e2e-kind-1_11
             - e2e-kind-1_13
             - e2e-kind-1_14
+            - e2e-kind-1_15
             # - e2e-benchmark-kind
           filters:
             branches:
@@ -469,6 +488,7 @@ workflows:
             - e2e-kind-1_11
             - e2e-kind-1_13
             - e2e-kind-1_14
+            - e2e-kind-1_15
             # - e2e-benchmark-kind
           filters:
             branches:

--- a/Dockerfile.kind
+++ b/Dockerfile.kind
@@ -1,3 +1,3 @@
-ARG BASE_IMAGE=dockertesteng/kind-node:v1.13.7-kind0.4.0
+ARG BASE_IMAGE=dockertesteng/kind-node:v1.14.3-kind0.4.0
 FROM ${BASE_IMAGE}
 COPY pre-loaded-images/*.tar kind/images/

--- a/Dockerfile.kind
+++ b/Dockerfile.kind
@@ -1,3 +1,3 @@
-ARG BASE_IMAGE=dockertesteng/kind-node:v1.13.3
+ARG BASE_IMAGE=dockertesteng/kind-node:v1.13.7-kind0.4.0
 FROM ${BASE_IMAGE}
 COPY pre-loaded-images/*.tar kind/images/

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -3,8 +3,8 @@ include common.mk
 BUILD_BASE_IMAGE = golang:1.12.6-alpine3.10
 TEST_BASE_IMAGE = golang:1.12.6
 RUN_BASE_IMAGE = alpine:3.10.0
-KUBERNETES_VERSION ?= 1.13.3
-KIND_TAG = v$(KUBERNETES_VERSION)-$(TAG)
+KUBERNETES_VERSION ?= 1.13.7
+KIND_VERSION ?= 0.4.0
 IMAGES = ${IMAGE_REPO_PREFIX}controller ${IMAGE_REPO_PREFIX}controller-coverage ${IMAGE_REPO_PREFIX}e2e-tests ${IMAGE_REPO_PREFIX}e2e-benchmark ${IMAGE_REPO_PREFIX}api-server ${IMAGE_REPO_PREFIX}api-server-coverage ${IMAGE_REPO_PREFIX}installer
 PUSH_IMAGES = push/${IMAGE_REPO_PREFIX}controller push/${IMAGE_REPO_PREFIX}api-server push/${IMAGE_REPO_PREFIX}installer
 DOCKERFILE = Dockerfile
@@ -86,13 +86,13 @@ save-coverage-images:
 	@mkdir -p pre-loaded-images
 	@docker save -o pre-loaded-images/coverage-enabled-images.tar ${IMAGE_REPO_PREFIX}api-server-coverage:$(TAG) ${IMAGE_REPO_PREFIX}controller-coverage:$(TAG)
 
-build-kind-image:
-	@echo "🌟 build ${IMAGE_REPO_PREFIX}e2e-kind-node:$(KIND_TAG)"
-	@tar cf - Dockerfile.kind pre-loaded-images | docker build -t ${IMAGE_REPO_PREFIX}e2e-kind-node:$(KIND_TAG) --build-arg BASE_IMAGE=dockertesteng/kind-node:v$(KUBERNETES_VERSION) -f Dockerfile.kind -
-
-create-kind-cluster: build-kind-image
+create-kind-cluster:
 	@echo "🌟 Create kind cluster"
-	@kind create cluster --name compose-on-kube --image ${IMAGE_REPO_PREFIX}e2e-kind-node:$(KIND_TAG)
+	@kind create cluster --name compose-on-kube --image dockertesteng/kind-node:v$(KUBERNETES_VERSION)-kind$(KIND_VERSION)
+
+load-kind-image-archive:
+	@echo "🌟 Load archive $(IMAGE_ARCHIVE) in kind cluster"
+	@kind load image-archive --name compose-on-kube $(IMAGE_ARCHIVE)
 
 delete-kind-cluster:
 	@echo "🌟 Delete kind cluster"

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -3,7 +3,7 @@ include common.mk
 BUILD_BASE_IMAGE = golang:1.12.6-alpine3.10
 TEST_BASE_IMAGE = golang:1.12.6
 RUN_BASE_IMAGE = alpine:3.10.0
-KUBERNETES_VERSION ?= 1.13.7
+KUBERNETES_VERSION ?= 1.14.3
 KIND_VERSION ?= 0.4.0
 IMAGES = ${IMAGE_REPO_PREFIX}controller ${IMAGE_REPO_PREFIX}controller-coverage ${IMAGE_REPO_PREFIX}e2e-tests ${IMAGE_REPO_PREFIX}e2e-benchmark ${IMAGE_REPO_PREFIX}api-server ${IMAGE_REPO_PREFIX}api-server-coverage ${IMAGE_REPO_PREFIX}installer
 PUSH_IMAGES = push/${IMAGE_REPO_PREFIX}controller push/${IMAGE_REPO_PREFIX}api-server push/${IMAGE_REPO_PREFIX}installer


### PR DESCRIPTION
In e2e tests
- bump kind to v0.4.0
- add kube 1.15.0 in list of clusters in e2e tests 