### PR TITLE
Avoid transient startup crash

### DIFF
--- a/cmd/api-server/cli/root.go
+++ b/cmd/api-server/cli/root.go
@@ -66,7 +66,7 @@ func NewCommandStartComposeServer(stopCh <-chan struct{}) *cobra.Command {
 				err = runComposeServer(o, stopCh)
 				// If the compose-api starts before the API server is listening then we can get a transient connection refused
 				// while looking up missing authentication information in the cluster (see #120).
-				if err != nil && strings.HasSuffix(err.Error(), "connection refused") {
+				if err != nil && strings.Contains(err.Error(), "connection refused") {
 					fmt.Fprintf(os.Stderr, "unable to start compose server: %s. Will retry in %s\n", err, nextBackoff)
 					time.Sleep(nextBackoff)
 					nextBackoff = nextBackoff * 2

--- a/cmd/api-server/cli/root.go
+++ b/cmd/api-server/cli/root.go
@@ -60,17 +60,22 @@ func NewCommandStartComposeServer(stopCh <-chan struct{}) *cobra.Command {
 			if err := utilerrors.NewAggregate(errors); err != nil {
 				return err
 			}
-			for {
-				err := runComposeServer(o, stopCh)
+			nextBackoff := time.Second
+			var err error
+			for attempt := 0; attempt < 8; attempt++ {
+				err = runComposeServer(o, stopCh)
 				// If the compose-api starts before the API server is listening then we can get a transient connection refused
 				// while looking up missing authentication information in the cluster (see #120).
 				if err != nil && strings.HasSuffix(err.Error(), "connection refused") {
-					fmt.Fprintf(os.Stderr, "unable to start compose server: %s. Will retry in 5s\n", err)
-					time.Sleep(5 * time.Second)
+					fmt.Fprintf(os.Stderr, "unable to start compose server: %s. Will retry in %s\n", err, nextBackoff)
+					time.Sleep(nextBackoff)
+					nextBackoff = nextBackoff * 2
 					continue
 				}
 				return err
 			}
+			fmt.Fprintf(os.Stderr, "giving up trying to start compose server")
+			return err
 		},
 	}
 


### PR DESCRIPTION
When the Kubernetes cluster is starting, the compose-api server startup can fail because the `o.RecommendedOptions.ApplyTo` will call into `o.Authentication.ApplyTo` which will call into
`lookupMissingConfigInCluster` which can fail to `Dial` the API server to query a config map because the API server has not fully started yet. This manifests as a panic and a print of the program's arguments.

This patch looks for this kind of transient `connection refused` error, logs and retries again in 5s so
- we don't panic() in the logs in a common / expected case
- we don't rely on Kubernetes restarting the pod during normal startup

This should fix #120

Note there is already precedent for retrying connection refused errors instead of crashing; for example:

```
W0725 10:31:53.877550       1 clientconn.go:1240] grpc: addrConn.createTransport failed to connect to {127.0.0.1:2379 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:2379: connect: connection refused". Reconnecting...
```

I tested this locally by patching the vendored k8s.io code to dial the wrong address 5 times. I saw the expected log entries 5 times and then it succeeded.