### PR TITLE
introduce support for GOPROXY

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
     steps:
       - attach_workspace:
           at: /root
@@ -130,6 +131,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
     steps:
       - attach_workspace:
           at: /root
@@ -141,6 +143,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
     steps:
       - attach_workspace:
           at: /root
@@ -150,6 +153,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
     steps:
       - attach_workspace:
           at: /root
@@ -182,12 +186,14 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
     steps: *e2e-kind-steps
   e2e-kind-1_11:
     docker: *public-golang
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
       KUBERNETES_VERSION: *kube_1_11
       KIND_VERSION: *kind_version
     steps: *e2e-kind-steps
@@ -196,6 +202,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
       KUBERNETES_VERSION: *kube_1_13
       KIND_VERSION: *kind_version
     steps: *e2e-kind-steps
@@ -204,6 +211,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
       KUBERNETES_VERSION: *kube_1_14
       KIND_VERSION: *kind_version
     steps: *e2e-kind-steps
@@ -212,6 +220,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
       KUBERNETES_VERSION: *kube_1_15
       KIND_VERSION: *kind_version
     steps: *e2e-kind-steps
@@ -220,6 +229,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
       KUBERNETES_VERSION: *kube_1_13
       KIND_VERSION: *kind_version
     steps: *e2e-benchmark-kind-steps
@@ -228,6 +238,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
     steps:
       - attach_workspace:
           at: /root
@@ -245,6 +256,7 @@ jobs:
     working_directory: /root/src/github.com/docker/compose-on-kubernetes
     environment:
       GOPATH: "/root"
+      GOPROXY: "direct"
     steps:
       - attach_workspace:
           at: /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apk add --no-cache \
   git \
   curl
 
+ARG GOPROXY
+
 WORKDIR /go/src/github.com/docker/compose-on-kubernetes
 COPY . .
 ARG BUILDTIME

--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -13,6 +13,8 @@ RUN apk add --no-cache \
   git \
   curl
 
+ARG GOPROXY
+
 WORKDIR /go/src/github.com/docker/compose-on-kubernetes
 COPY . .
 ARG BUILDTIME

--- a/Dockerfile.debuggable
+++ b/Dockerfile.debuggable
@@ -7,6 +7,8 @@ RUN apk add --no-cache \
   coreutils \
   make \
   git
+ARG GOPROXY
+
 RUN --mount=target=/root/.cache,type=cache git clone https://github.com/derekparker/delve.git /go/src/github.com/derekparker/delve && \
   cd /go/src/github.com/derekparker/delve && \
   git checkout v1.1.0 && \

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -14,10 +14,11 @@ endif
 BUILD_ARGS = \
   --build-arg BUILD_BASE=${BUILD_BASE_IMAGE} \
   --build-arg RUN_BASE=${RUN_BASE_IMAGE} \
-  --build-arg BUILDTIME=${BUILDTIME} \
-  --build-arg GITCOMMIT=${GITCOMMIT} \
-  --build-arg VERSION=${VERSION} \
-  --build-arg IMAGE_REPO_PREFIX=${IMAGE_REPO_PREFIX}
+  --build-arg BUILDTIME \
+  --build-arg GITCOMMIT \
+  --build-arg VERSION \
+  --build-arg IMAGE_REPO_PREFIX \
+  --build-arg GOPROXY
 
 build-validate-image: ## create the image used for validation
 	@tar cf - ${DOCKERFILE} doc.go Makefile common.mk cmd install api internal vendor e2e dockerfiles scripts gometalinter.json Gopkg.toml Gopkg.lock .git | docker build --build-arg BUILD_BASE=${BUILD_BASE_IMAGE} -t kube-compose-validate -f ./dockerfiles/Dockerfile.dev --target lint -


### PR DESCRIPTION
use of `--build-arg FOO` without a value allows to pass FOO environment variable if it's set on environment, and just skip build arg if not set.
same for `ARG FOO` without a value.
Doing so, default golang behaviour is preserver but we can change it with environment variable