### PR TITLE
Fix kind versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2
 aliases:
   kube_versions:
     - kube_1_11: &kube_1_11 "1.11.10"
-    - kube_1_13: &kube_1_13 "1.13.11"
-    - kube_1_14: &kube_1_14 "1.14.7"
-    - kube_1_15: &kube_1_15 "1.15.4"
+    - kube_1_13: &kube_1_13 "1.13.10"
+    - kube_1_14: &kube_1_14 "1.14.6"
+    - kube_1_15: &kube_1_15 "1.15.3"
     - kube_1_16: &kube_1_16 "1.16.1"
   docker-login: &docker-login
     username: $DOCKER_USER


### PR DESCRIPTION
The kind versions that I had specified don't exist but are only part of the master/tag CI pipeline so I didn't catch it. This should fix the CI.