### PR TITLE
Remove call to deprecated K8s function

### DIFF
--- a/internal/conversions/v1alpha3.go
+++ b/internal/conversions/v1alpha3.go
@@ -16,14 +16,43 @@ import (
 // RegisterV1alpha3Conversions adds conversion functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterV1alpha3Conversions(scheme *runtime.Scheme) error {
-	return scheme.AddConversionFuncs(
-		ownerToInternalV1alpha3,
-		ownerFromInternalV1alpha3,
-		stackToInternalV1alpha3,
-		stackFromInternalV1alpha3,
-		stackListToInternalV1alpha3,
-		stackListFromInternalV1alpha3,
-	)
+	if err := scheme.AddConversionFunc((*v1alpha3.Owner)(nil), (*internalversion.Owner)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return ownerToInternalV1alpha3(a.(*v1alpha3.Owner), b.(*internalversion.Owner), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*internalversion.Owner)(nil), (*v1alpha3.Owner)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return ownerFromInternalV1alpha3(a.(*internalversion.Owner), b.(*v1alpha3.Owner), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*v1alpha3.Stack)(nil), (*internalversion.Stack)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackToInternalV1alpha3(a.(*v1alpha3.Stack), b.(*internalversion.Stack), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*internalversion.Stack)(nil), (*v1alpha3.Stack)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackFromInternalV1alpha3(a.(*internalversion.Stack), b.(*v1alpha3.Stack), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*v1alpha3.StackList)(nil), (*internalversion.StackList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackListToInternalV1alpha3(a.(*v1alpha3.StackList), b.(*internalversion.StackList), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*internalversion.StackList)(nil), (*v1alpha3.StackList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackListFromInternalV1alpha3(a.(*internalversion.StackList), b.(*v1alpha3.StackList), scope)
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ownerToInternalV1alpha3(in *v1alpha3.Owner, out *internalversion.Owner, _ conversion.Scope) error {

--- a/internal/conversions/v1alpha3_test.go
+++ b/internal/conversions/v1alpha3_test.go
@@ -1,1 +1,34 @@
 package conversions
+
+import (
+	"testing"
+
+	"github.com/docker/compose-on-kubernetes/api/compose/impersonation"
+	"github.com/docker/compose-on-kubernetes/api/compose/v1alpha3"
+	"github.com/docker/compose-on-kubernetes/internal/internalversion"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestRegisterV1alpha3Conversions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	RegisterV1alpha3Conversions(scheme)
+
+	v1alpha3Owner := &v1alpha3.Owner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "owner",
+		},
+		Owner: impersonation.Config{
+			UserName: "foo",
+		},
+	}
+	internalversionOwner := &internalversion.Owner{}
+	scheme.Convert(v1alpha3Owner, internalversionOwner, nil)
+	assert.Equal(t, "owner", internalversionOwner.ObjectMeta.Name)
+	assert.Equal(t, "foo", internalversionOwner.Owner.UserName)
+
+	internalversionOwner.Owner.UserName = "bar"
+	scheme.Convert(internalversionOwner, v1alpha3Owner, nil)
+	assert.Equal(t, "bar", v1alpha3Owner.Owner.UserName)
+}

--- a/internal/conversions/v1beta1.go
+++ b/internal/conversions/v1beta1.go
@@ -10,15 +10,43 @@ import (
 // RegisterV1beta1Conversions adds conversion functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterV1beta1Conversions(scheme *runtime.Scheme) error {
+	if err := scheme.AddConversionFunc((*v1beta1.Owner)(nil), (*internalversion.Owner)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return ownerToInternalV1beta1(a.(*v1beta1.Owner), b.(*internalversion.Owner), scope)
+	}); err != nil {
+		return err
+	}
 
-	return scheme.AddConversionFuncs(
-		ownerToInternalV1beta1,
-		ownerFromInternalV1beta1,
-		stackToInternalV1beta1,
-		stackFromInternalV1beta1,
-		stackListToInternalV1beta1,
-		stackListFromInternalV1beta1,
-	)
+	if err := scheme.AddConversionFunc((*internalversion.Owner)(nil), (*v1beta1.Owner)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return ownerFromInternalV1beta1(a.(*internalversion.Owner), b.(*v1beta1.Owner), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*v1beta1.Stack)(nil), (*internalversion.Stack)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackToInternalV1beta1(a.(*v1beta1.Stack), b.(*internalversion.Stack), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*internalversion.Stack)(nil), (*v1beta1.Stack)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackFromInternalV1beta1(a.(*internalversion.Stack), b.(*v1beta1.Stack), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*v1beta1.StackList)(nil), (*internalversion.StackList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackListToInternalV1beta1(a.(*v1beta1.StackList), b.(*internalversion.StackList), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*internalversion.StackList)(nil), (*v1beta1.StackList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackListFromInternalV1beta1(a.(*internalversion.StackList), b.(*v1beta1.StackList), scope)
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ownerToInternalV1beta1(in *v1beta1.Owner, out *internalversion.Owner, _ conversion.Scope) error {

--- a/internal/conversions/v1beta2.go
+++ b/internal/conversions/v1beta2.go
@@ -11,14 +11,43 @@ import (
 // RegisterV1beta2Conversions adds conversion functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterV1beta2Conversions(scheme *runtime.Scheme) error {
-	return scheme.AddConversionFuncs(
-		ownerToInternalV1beta2,
-		ownerFromInternalV1beta2,
-		stackToInternalV1beta2,
-		stackFromInternalV1beta2,
-		stackListToInternalV1beta2,
-		stackListFromInternalV1beta2,
-	)
+	if err := scheme.AddConversionFunc((*v1beta2.Owner)(nil), (*internalversion.Owner)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return ownerToInternalV1beta2(a.(*v1beta2.Owner), b.(*internalversion.Owner), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*internalversion.Owner)(nil), (*v1beta2.Owner)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return ownerFromInternalV1beta2(a.(*internalversion.Owner), b.(*v1beta2.Owner), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*v1beta2.Stack)(nil), (*internalversion.Stack)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackToInternalV1beta2(a.(*v1beta2.Stack), b.(*internalversion.Stack), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*internalversion.Stack)(nil), (*v1beta2.Stack)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackFromInternalV1beta2(a.(*internalversion.Stack), b.(*v1beta2.Stack), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*v1beta2.StackList)(nil), (*internalversion.StackList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackListToInternalV1beta2(a.(*v1beta2.StackList), b.(*internalversion.StackList), scope)
+	}); err != nil {
+		return err
+	}
+
+	if err := scheme.AddConversionFunc((*internalversion.StackList)(nil), (*v1beta2.StackList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return stackListFromInternalV1beta2(a.(*internalversion.StackList), b.(*v1beta2.StackList), scope)
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ownerToInternalV1beta2(in *v1beta2.Owner, out *internalversion.Owner, _ conversion.Scope) error {


### PR DESCRIPTION
`AddConversionFuncs` in `k8s.io/apimachinery/pkg/runtime.Scheme` is deprecated and removed in k8s 1.18 (cf https://github.com/kubernetes/kubernetes/pull/85891).

This change replaces the deprecated registration code to this (more verbose) registration code, which will continue to be supported in K8s 1.18+.
