### PR TITLE
Fix license checks

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -4,11 +4,11 @@ blacklist:
 
 whitelist:
   - Apache-2.0
-  - FreeBSD
+  - BSD-2-Clause
+  - BSD-3-Clause
   - LGPL-3.0
   - MIT
   - MPL-2.0
-  - NewBSD
 
 exceptions:
   - bitbucket.org/ww/goautoneg # Unknown

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -12,18 +12,9 @@ whitelist:
 
 exceptions:
   - bitbucket.org/ww/goautoneg # Unknown
-  - github.com/BurntSushi/toml # MIT
   - github.com/davecgh/go-spew/spew # ISC
-  - github.com/howeyc/gopass # ISC
   - github.com/munnerz/goautoneg # Unknown
   - github.com/opencontainers/go-digest # Apache-2.0
   - github.com/xeipuuv/gojsonpointer # Apache-2.0
   - github.com/xeipuuv/gojsonreference # Apache-2.0
   - github.com/xeipuuv/gojsonschema # Apache-2.0
-  - k8s.io/metrics/pkg/apis/metrics # Unknown
-  - k8s.io/metrics/pkg/apis/metrics/v1alpha1 # Unknown
-  - k8s.io/metrics/pkg/apis/metrics/v1beta1 # Unknown
-  - k8s.io/metrics/pkg/client/clientset_generated/clientset # Unknown
-  - k8s.io/metrics/pkg/client/clientset_generated/clientset/scheme # Unknown
-  - k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1 # Unknown
-  - k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1 # Unknown

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -6,15 +6,12 @@ whitelist:
   - Apache-2.0
   - BSD-2-Clause
   - BSD-3-Clause
+  - ISC
   - LGPL-3.0
   - MIT
   - MPL-2.0
 
 exceptions:
   - bitbucket.org/ww/goautoneg # Unknown
-  - github.com/davecgh/go-spew/spew # ISC
   - github.com/munnerz/goautoneg # Unknown
   - github.com/opencontainers/go-digest # Apache-2.0
-  - github.com/xeipuuv/gojsonpointer # Apache-2.0
-  - github.com/xeipuuv/gojsonreference # Apache-2.0
-  - github.com/xeipuuv/gojsonschema # Apache-2.0

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -14,4 +14,4 @@ whitelist:
 exceptions:
   - bitbucket.org/ww/goautoneg # BSD-3-Clause, license is in the source, misdetected as Apache-2.0
   - github.com/munnerz/goautoneg # BSD-3-Clause, license is in the source
-  - github.com/opencontainers/go-digest # Apache-2.0
+  - github.com/opencontainers/go-digest # Apache-2.0, misdetected as CC-BY-SA-4.0

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -12,6 +12,6 @@ whitelist:
   - MPL-2.0
 
 exceptions:
-  - bitbucket.org/ww/goautoneg # Unknown
-  - github.com/munnerz/goautoneg # Unknown
+  - bitbucket.org/ww/goautoneg # BSD-3-Clause, license is in the source, misdetected as Apache-2.0
+  - github.com/munnerz/goautoneg # BSD-3-Clause, license is in the source
   - github.com/opencontainers/go-digest # Apache-2.0


### PR DESCRIPTION
This fixes the [wwhrd](https://github.com/frapposelli/wwhrd)-based license checks which are currently failed by the CI pipeline even when nothing new is vendored.

Fixes: #169

Summary of changes:
* Fixed naming of `BSD-2-Clause` and `BSD-3-Clause` licenses due to change in underlying library in wwhrd
* Added `ISC` to license allow-list now that wwhrd can distinguish it from 0BSD
* Removed no-longer-needed exceptions, either for no-longer-used libraries, or where wwhrd now detects the license correctly
* Documented the remaining exceptions as to _why_ they are exceptions:
* * Two libraries have not been revendored since fixes were made to allow license-checkers to detect them correctly
* * One library is inlined into another library, and because it's an old copy of one of the above two, is mis-detected with the inlining library's license.

<details>
<summary> Changes obsoleted by improvements to wwhrd after I started this work.</summary>
Mostly this was janitorial (BSD licenses were misnamed, a few libraries were not detected correctly by wwhrd and needed exceptions, and some exceptions had been left behind after their usage was removed).

I also filed https://github.com/frapposelli/wwhrd/issues/40 for the go-spew misdetection in wwhrd.

The most significant change is explicit acceptance of `MPL-2.0-no-copyleft-exception` and requisite blacklisting of `GPL-2.0+`, `LGPL-2.1+` and `AFGPL-3.0+`. This is due to usage of [`github.com/hashicorp/golang-lru/simplelru`](https://pkg.go.dev/github.com/hashicorp/golang-lru/simplelru?tab=licenses). There is an open issue (https://github.com/hashicorp/golang-lru/issues/62) requesting the license be changed to `MPL-2.0` but no apparent action has been taken.
</details>