### PR TITLE
license-check: add BSD-3-Clause to allow-list

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -4,6 +4,8 @@ blacklist:
 
 whitelist:
   - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
   - FreeBSD
   - LGPL-3.0
   - MIT


### PR DESCRIPTION
We're using dependencies with this license in many places, and it should
be ok to use.
